### PR TITLE
Declare the Background Workers to be of specific types

### DIFF
--- a/bdr_perdb.c
+++ b/bdr_perdb.c
@@ -237,7 +237,7 @@ getattno(const char *colname)
 void
 bdr_maintain_db_workers(void)
 {
-	BackgroundWorker bgw;
+	BackgroundWorker bgw = {0};
 	int			i,
 				ret;
 	int			nnodes = 0;
@@ -285,7 +285,6 @@ bdr_maintain_db_workers(void)
 	bgw.bgw_flags = BGWORKER_SHMEM_ACCESS |
 		BGWORKER_BACKEND_DATABASE_CONNECTION;
 	bgw.bgw_start_time = BgWorkerStart_RecoveryFinished;
-	/* bgw.bgw_main = NULL; */
 	strncpy(bgw.bgw_library_name, BDR_LIBRARY_NAME, BGW_MAXLEN);
 	strncpy(bgw.bgw_function_name, "bdr_apply_main", BGW_MAXLEN);
 	bgw.bgw_restart_time = 5;
@@ -708,6 +707,7 @@ bdr_maintain_db_workers(void)
 				 "bdr apply %s to %s",
 				 bdr_nodeid_name(&target, true),
 				 bdr_nodeid_name(&myid, true));
+		snprintf(bgw.bgw_type, BGW_MAXLEN, "bdr apply");
 
 		/* Allocate a new shmem slot for this apply worker */
 		worker = bdr_worker_shmem_alloc(BDR_WORKER_APPLY, &slot);

--- a/bdr_supervisor.c
+++ b/bdr_supervisor.c
@@ -54,7 +54,7 @@ static void
 bdr_register_perdb_worker(const char *dbname)
 {
 	BackgroundWorkerHandle *bgw_handle;
-	BackgroundWorker bgw;
+	BackgroundWorker bgw = {0};
 	BdrWorker  *worker;
 	BdrPerdbWorker *perdb;
 	unsigned int worker_slot_number;
@@ -86,13 +86,12 @@ bdr_register_perdb_worker(const char *dbname)
 	bgw.bgw_flags = BGWORKER_SHMEM_ACCESS |
 		BGWORKER_BACKEND_DATABASE_CONNECTION;
 	bgw.bgw_start_time = BgWorkerStart_RecoveryFinished;
-	/* bgw.bgw_main = NULL; */
 	strncpy(bgw.bgw_library_name, BDR_LIBRARY_NAME, BGW_MAXLEN);
 	strncpy(bgw.bgw_function_name, "bdr_perdb_worker_main", BGW_MAXLEN);
 	bgw.bgw_restart_time = 5;
 	bgw.bgw_notify_pid = 0;
-	snprintf(bgw.bgw_name, BGW_MAXLEN,
-			 "bdr db: %s", dbname);
+	snprintf(bgw.bgw_name, BGW_MAXLEN, "bdr worker for \"%s\" database", dbname);
+	snprintf(bgw.bgw_type, BGW_MAXLEN, "bdr worker");
 
 	/*
 	 * The main arg is composed of two uint16 parts - the worker generation
@@ -465,7 +464,7 @@ bdr_supervisor_worker_main(Datum main_arg)
 void
 bdr_supervisor_register()
 {
-	BackgroundWorker bgw;
+	BackgroundWorker bgw = {0};
 
 	Assert(IsPostmasterEnvironment && !IsUnderPostmaster);
 
@@ -477,13 +476,12 @@ bdr_supervisor_register()
 	bgw.bgw_flags = BGWORKER_SHMEM_ACCESS |
 		BGWORKER_BACKEND_DATABASE_CONNECTION;
 	bgw.bgw_start_time = BgWorkerStart_RecoveryFinished;
-	/* bgw.bgw_main = NULL; */
 	strncpy(bgw.bgw_library_name, BDR_LIBRARY_NAME, BGW_MAXLEN);
 	strncpy(bgw.bgw_function_name, "bdr_supervisor_worker_main", BGW_MAXLEN);
 	bgw.bgw_restart_time = 1;
 	bgw.bgw_notify_pid = 0;
-	snprintf(bgw.bgw_name, BGW_MAXLEN,
-			 "bdr supervisor");
+	snprintf(bgw.bgw_name, BGW_MAXLEN, "bdr supervisor");
+	snprintf(bgw.bgw_type, BGW_MAXLEN, "bdr supervisor");
 	bgw.bgw_main_arg = Int32GetDatum(0);	/* unused */
 
 	RegisterBackgroundWorker(&bgw);


### PR DESCRIPTION
This fix was prompted by the following message in the server logs.

> LOG:  background worker "??H??" (PID 27511) exited with exit code 1

Postgres version 11 introduced the bgw_type field, and it is intended to
be used for process grouping in pg_stat_activity view. Since the BDR
code does not initialize the struct with zeroed-out memory, the Postgres
code uses the uninitialized struct member's contents and prints garbage.

We initialize the struct with zeroes, so that any uniniitialized fields
introduced in future don't get populated with garbage. Second, it
assigns the appropriate names and types to the workers.