### PR TITLE
Deduplicate replication origin name forming code

### DIFF
--- a/bdr_catalogs.c
+++ b/bdr_catalogs.c
@@ -476,13 +476,14 @@ bdr_replident_name(const BDRNodeId * const remote, Oid local_dboid)
 RepOriginId
 bdr_fetch_node_id_via_sysid(const BDRNodeId * const node)
 {
-	char		ident[256];
+	char	*ident;
+	RepOriginId id;
 
-	snprintf(ident, sizeof(ident),
-			 BDR_REPORIGIN_ID_FORMAT,
-			 node->sysid, node->timeline, node->dboid, MyDatabaseId,
-			 EMPTY_REPLICATION_NAME);
-	return replorigin_by_name(ident, false);
+	ident = bdr_replident_name(node, MyDatabaseId);
+	id = replorigin_by_name(ident, false);
+	pfree(ident);
+
+	return id;
 }
 
 /*

--- a/bdr_init_copy.c
+++ b/bdr_init_copy.c
@@ -1284,7 +1284,8 @@ initialize_replication_identifier(PGconn *conn, NodeInfo *ni, Oid dboid, char *r
 	PQExpBuffer query = createPQExpBuffer();
 
 	snprintf(remote_ident, sizeof(remote_ident), BDR_REPORIGIN_ID_FORMAT,
-				ni->remote_sysid, ni->remote_tlid, dboid, dboid, "");
+			 ni->remote_sysid, ni->remote_tlid, dboid, dboid,
+			 EMPTY_REPLICATION_NAME);
 
 	printfPQExpBuffer(query, "SELECT pg_catalog.pg_replication_origin_create('%s')",
 					  remote_ident);


### PR DESCRIPTION
Using bdr_replident_name() to form replication origin name helps eliminate duplicate code and centralizes the logic.

There's another place where replication origin name is determined from NodeInfo structure unlike bdr_replident_name() which uses BDRNodeId. Since that code isn't duplicated i.e. used in only one place in initialize_replication_identifier() it's not worth a function for now. In passing, use EMPTY_REPLICATION_NAME instead of hard-coded empty string there for better readability.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
