### PR TITLE
Setup CI pipeline for running BDR tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,66 @@
+name: BDR CI
+on:
+  schedule:
+    # Runs every 3 hours.
+    - cron: '0 */3 * * *'
+  push:
+  pull_request:
+jobs:
+  build-and-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        version: [REL_11_STABLE]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+
+    steps:
+      - name: Test details
+        run: echo Build and test BDR on ${{ matrix.os }} with PostgreSQL ${{ matrix.version }} branch
+
+      - name: Checkout and build PostgreSQL code
+        run: |
+          sudo apt-get update -qq
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+          sudo apt-get install -qq acl bison flex libssl-dev libreadline-dev libxml2-dev libssl-dev libperl-dev libipc-run-perl pkg-config libxml2-utils libxslt1-dev xsltproc docbook-xsl
+          rm -rf postgres
+          git clone --branch ${{ matrix.version }} https://github.com/postgres/postgres.git
+          pushd postgres
+          git branch
+          ./configure --prefix=$PWD/inst/ --enable-debug --enable-cassert --enable-tap-tests CFLAGS="-ggdb3 -O0"
+          make -j4 install
+
+          # Here we just initialize the cluster and see if postgres comes up
+          # and stop. We could further run basic postgres tests with
+          # "make installcheck", but that's not the intention of this test.
+          cd inst/bin
+          ./initdb -D data
+          ./pg_ctl -D data -l logfile start
+          ./pg_ctl -D data -l logfile stop
+          cd ../..
+
+          # Create the directory for BDR extension checkout.
+          mkdir contrib/bdr
+          popd
+
+      - name: Checkout BDR extension code
+        uses: actions/checkout@v3
+        with:
+          path: postgres/contrib/bdr
+
+      - name: Build and test BDR extension
+        run: |
+          pushd postgres
+
+          # Install extensions required by BDR for tests.
+          make -C contrib/btree_gist install
+          make -C contrib/cube install
+          make -C contrib/hstore install
+          make -C contrib/pg_trgm install
+
+          cd contrib/bdr
+          PATH=$GITHUB_WORKSPACE/postgres/inst/bin:"$PATH" ./configure
+          make check || (cat regression.diffs && false)
+          popd
+          # Clean the directory.
+          rm -rf postgres


### PR DESCRIPTION
This commit sets up CI pipeline for BDR - a github workflow to run regression tests (both SQL tests and TAP tests).

It currently runs tests on upstream postgres REL_11_STABLE branch and is likely to be extended for other branches as well once BDR code is extended to work on those branches.

Tests are scheduled to run every 3 hours and upon a new push or PR. The 3 hourely run might have to change, but for now, it helps to catch any test failures.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
