### PR TITLE
Fix Shut down the perdb worker in remove_bdr_from_local_node()

### DIFF
--- a/extsql/bdr--2.0.7.0.sql
+++ b/extsql/bdr--2.0.7.0.sql
@@ -2580,9 +2580,9 @@ BEGIN
 
   -- Shut down the perdb worker
   PERFORM pg_terminate_backend(pid)
-  FROM pg_stat_activity, bdr.bdr_get_local_nodeid() ni
+  FROM pg_stat_activity, bdr.bdr_get_local_node_name() lnn
   WHERE datname = current_database()
-    AND application_name = format('bdr: (%s,%s,%s,):perdb', ni.sysid, ni.timeline, ni.dboid);
+    AND application_name = format('%s:perdb', lnn);
 
   -- Clear out the rest of bdr_nodes and bdr_connections
   DELETE FROM bdr.bdr_nodes;


### PR DESCRIPTION
Without the fix the perdb worker is not shut down.

Indeed:
```
abba=# select pid, application_name FROM pg_stat_activity, bdr.bdr_get_local_nodeid() ni WHERE datname = current_database() and application_name = format('bdr: (%s,%s,%s,):perdb', ni.sysid, ni.timeline, ni.dboid);;
 pid | application_name
-----+------------------
(0 rows)
```
While:
```
abba=# select pid, application_name FROM pg_stat_activity, bdr.bdr_get_local_node_name() lnn WHERE datname = current_database() and application_name = format('%s:perdb', lnn);
   pid   | application_name
---------+------------------
 1595065 | node1:perdb
(1 row)
```

Discovered during https://github.com/aws/abba-pg-bdr/issues/31
