### PR TITLE
prevent apply worker to start if node has been parted

### DIFF
--- a/bdr_init_replica.c
+++ b/bdr_init_replica.c
@@ -959,6 +959,7 @@ bdr_init_replica(BDRNodeInfo * local_node)
 	PGconn	   *nonrepl_init_conn;
 	StringInfoData dsn;
 	BdrConnectionConfig *local_conn_config;
+	bool	config_found;
 
 	initStringInfo(&dsn);
 
@@ -1006,7 +1007,7 @@ bdr_init_replica(BDRNodeInfo * local_node)
 		return;
 	}
 
-	local_conn_config = bdr_get_connection_config(&local_node->id, true);
+	local_conn_config = bdr_get_connection_config(&local_node->id, true, &config_found);
 
 	if (!local_conn_config)
 		elog(ERROR, "cannot find local BDR connection configurations");

--- a/bdr_internal.h
+++ b/bdr_internal.h
@@ -93,8 +93,8 @@ extern volatile sig_atomic_t got_SIGHUP;
 
 extern void bdr_error_nodeids_must_differ(const BDRNodeId * const other_nodeid);
 extern BdrConnectionConfig * bdr_get_connection_config(const BDRNodeId * nodeid,
-													   bool missing_ok);
-extern BdrConnectionConfig * bdr_get_my_connection_config(bool missing_ok);
+													   bool missing_ok, bool *config_found);
+extern BdrConnectionConfig * bdr_get_my_connection_config(bool missing_ok, bool *config_found);
 
 extern void bdr_free_connection_config(BdrConnectionConfig * cfg);
 

--- a/bdr_remotecalls.c
+++ b/bdr_remotecalls.c
@@ -765,6 +765,7 @@ bdr_drop_remote_slot(PG_FUNCTION_ARGS)
 	NameData	slotname;
 	BdrConnectionConfig *cfg;
 	BDRNodeId	remote;
+	bool	config_found;
 
 	remote.timeline = PG_GETARG_OID(1);
 	remote.dboid = PG_GETARG_OID(2);
@@ -772,7 +773,7 @@ bdr_drop_remote_slot(PG_FUNCTION_ARGS)
 	if (sscanf(remote_sysid_str, UINT64_FORMAT, &remote.sysid) != 1)
 		elog(ERROR, "parsing of remote sysid as uint64 failed");
 
-	cfg = bdr_get_connection_config(&remote, false);
+	cfg = bdr_get_connection_config(&remote, false, &config_found);
 	conn = bdr_connect_nonrepl(cfg->dsn, "bdr_drop_replication_slot");
 	bdr_free_connection_config(cfg);
 


### PR DESCRIPTION
Indeed when a node is parted we can see things like:

2023-06-06 06:41:20.240 UTC [1629541] LOG:  this node has been parted, not starting connections 2023-06-06 06:41:25.248 UTC [1631199] ERROR:  failed to find expected bdr.connections row (conn_sysid,conn_timeline,conn_dboid) = (7241459110514653804,1,16385) in bdr.bdr_connections 2023-06-06 06:41:25.248 UTC [1631201] ERROR:  failed to find expected bdr.connections row (conn_sysid,conn_timeline,conn_dboid) = (7241459110514653804,1,16385) in bdr.bdr_connections 2023-06-06 06:41:25.250 UTC [1629521] LOG:  background worker "bdr apply worker" (PID 1631199) exited with exit code 1 2023-06-06 06:41:25.250 UTC [1629521] LOG:  background worker "bdr apply worker" (PID 1631201) exited with exit code 1 2023-06-06 06:41:30.263 UTC [1631203] ERROR:  failed to find expected bdr.connections row (conn_sysid,conn_timeline,conn_dboid) = (7241459110514653804,1,16385) in bdr.bdr_connections 2023-06-06 06:41:30.263 UTC [1631204] ERROR:  failed to find expected bdr.connections row (conn_sysid,conn_timeline,conn_dboid) = (7241459110514653804,1,16385) in bdr.bdr_connections 2023-06-06 06:41:30.265 UTC [1629521] LOG:  background worker "bdr apply worker" (PID 1631203) exited with exit code 1 2023-06-06 06:41:30.265 UTC [1629521] LOG:  background worker "bdr apply worker" (PID 1631204) exited with exit code 1 2023-06-06 06:41:35.277 UTC [1631205] ERROR:  failed to find expected bdr.connections row (conn_sysid,conn_timeline,conn_dboid) = (7241459110514653804,1,16385) in bdr.bdr_connections 2023-06-06 06:41:35.278 UTC [1631206] ERROR:  failed to find expected bdr.connections row (conn_sysid,conn_timeline,conn_dboid) = (7241459110514653804,1,16385) in bdr.bdr_connections 2023-06-06 06:41:35.279 UTC [1629521] LOG:  background worker "bdr apply worker" (PID 1631205) exited with exit code 1 2023-06-06 06:41:35.280 UTC [1629521] LOG:  background worker "bdr apply worker" (PID 1631206) exited with exit code 1 .
.
.

With the patch we get:

2023-06-06 06:56:18.873 UTC [1632838] LOG:  this node has been parted, not starting connections
2023-06-06 06:56:23.882 UTC [1634679] LOG:  failed to find expected bdr.connections row (conn_sysid,conn_timeline,conn_dboid) = (7241460118650111818,1,16385) in bdr.bdr_connections
2023-06-06 06:56:23.882 UTC [1634679] LOG:  unregistering worker, config not found
2023-06-06 06:56:23.883 UTC [1634680] LOG:  failed to find expected bdr.connections row (conn_sysid,conn_timeline,conn_dboid) = (7241460118650111818,1,16385) in bdr.bdr_connections
2023-06-06 06:56:23.883 UTC [1634680] LOG:  unregistering worker, config not found


