### PR TITLE
Unregister BDR workers to prevent fail-and-restart cycles

### DIFF
--- a/bdr.h
+++ b/bdr.h
@@ -637,7 +637,8 @@ extern int	bdr_parse_version(const char *bdr_version_str, int *o_major,
 							  int *o_minor, int *o_rev, int *o_subrev);
 
 /* manipulation of bdr catalogs */
-extern BdrNodeStatus bdr_nodes_get_local_status(const BDRNodeId * const node);
+extern BdrNodeStatus bdr_nodes_get_local_status(const BDRNodeId * const node,
+												bool missing_ok);
 extern BDRNodeInfo * bdr_nodes_get_local_info(const BDRNodeId * const node);
 extern void bdr_bdr_node_free(BDRNodeInfo * node);
 extern void bdr_nodes_set_local_status(BdrNodeStatus status, BdrNodeStatus oldstatus);

--- a/bdr_apply.c
+++ b/bdr_apply.c
@@ -2847,13 +2847,14 @@ bdr_apply_main(Datum main_arg)
 	StartTransactionCommand();
 	SPI_connect();
 	PushActiveSnapshot(GetTransactionSnapshot());
-	status = bdr_nodes_get_local_status(&bdr_apply_worker->remote_node);
+	status = bdr_nodes_get_local_status(&bdr_apply_worker->remote_node, false);
 	SPI_finish();
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 	if (status == BDR_NODE_STATUS_KILLED)
 	{
-		elog(LOG, "unregistering worker, node has been killed");
+		elog(LOG, "unregistering apply worker due to remote node " BDR_NODEID_FORMAT " part",
+			 BDR_NODEID_FORMAT_ARGS(bdr_apply_worker->remote_node));
 		bdr_worker_shmem_free(bdr_worker_slot, NULL);
 		bdr_worker_slot = NULL;
 		proc_exit(0);			/* unregister */

--- a/bdr_init_replica.c
+++ b/bdr_init_replica.c
@@ -899,7 +899,7 @@ bdr_wait_for_local_node_ready()
 		StartTransactionCommand();
 		SPI_connect();
 		PushActiveSnapshot(GetTransactionSnapshot());
-		status = bdr_nodes_get_local_status(&myid);
+		status = bdr_nodes_get_local_status(&myid, false);
 		PopActiveSnapshot();
 		SPI_finish();
 		CommitTransactionCommand();

--- a/bdr_perdb.c
+++ b/bdr_perdb.c
@@ -292,7 +292,7 @@ bdr_maintain_db_workers(void)
 	SPI_connect();
 	PushActiveSnapshot(GetTransactionSnapshot());
 
-	our_status = bdr_nodes_get_local_status(&myid);
+	our_status = bdr_nodes_get_local_status(&myid, false);
 
 	/*
 	 * First check whether any existing processes to/from this database need

--- a/t/045_unregister_workers_after_part.pl
+++ b/t/045_unregister_workers_after_part.pl
@@ -1,0 +1,87 @@
+#!/usr/bin/env perl
+#
+# Test unregistering per-db/apply worker after parting.
+use strict;
+use warnings;
+use lib 't/';
+use Cwd;
+use Config;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Time::HiRes qw(usleep);
+use IPC::Run;
+use Test::More;
+use utils::nodemanagement;
+
+# Create an upstream node and bring up bdr
+my $nodes = make_bdr_group(3,'node_');
+my ($node_0,$node_1,$node_2) = @$nodes;
+
+# Part a node from 3 node cluster
+note "Part node_0 from 3 node cluster\n";
+part_nodes([$node_0], $node_1);
+check_part_statuses([$node_0], $node_1);
+
+my $logstart_0 = get_log_size($node_0);
+my $logstart_1 = get_log_size($node_1);
+
+# Parted node must unregister apply worker
+my $result = wait_for_worker_to_unregister($node_0,
+	qr!LOG: ( [A-Z0-9]+:)? unregistering apply worker due to .*!,
+	$logstart_0);
+ok($result, "unregistering apply worker on node_0 is detected");
+
+# Remove BDR from the parted node
+$node_0->safe_psql($bdr_test_dbname, "select bdr.remove_bdr_from_local_node()");
+
+# per-db worker must be unregistered on a node with BDR removed
+$result = wait_for_worker_to_unregister($node_0,
+	qr!LOG: ( [A-Z0-9]+:)? unregistering per-db worker due to .*!,
+	$logstart_0);
+ok($result, "unregistering per-db worker on node_0 is detected");
+
+# Remove BDR from node and immediately drop the extension
+$node_1->safe_psql($bdr_test_dbname,
+	q[
+		SELECT bdr.remove_bdr_from_local_node(true);
+		DROP EXTENSION bdr;
+	]);
+
+# Parted node must unregister apply worker
+$result = wait_for_worker_to_unregister($node_1,
+	qr!LOG: ( [A-Z0-9]+:)? unregistering apply worker due to .*!,
+	$logstart_1);
+ok($result, "unregistering apply worker on node_1 is detected");
+
+# per-db worker must be unregistered on a node with BDR removed
+$result = wait_for_worker_to_unregister($node_1,
+	qr!LOG: ( [A-Z0-9]+:)? unregistering per-db worker due to .*!,
+	$logstart_1);
+ok($result, "unregistering per-db worker on node_1 is detected");
+
+done_testing();
+
+# Return the size of logfile of $node in bytes
+sub get_log_size
+{
+	my ($node) = @_;
+
+	return (stat $node->logfile)[7];
+}
+
+# Find $pat in logfile of $node after $off-th byte
+sub wait_for_worker_to_unregister
+{
+	my ($node, $pat, $off) = @_;
+	my $max_attempts = $PostgreSQL::Test::Utils::timeout_default * 10;
+	my $log;
+
+	while ($max_attempts-- >= 0)
+	{
+		$log = PostgreSQL::Test::Utils::slurp_file($node->logfile, $off);
+		last if ($log =~ m/$pat/);
+		usleep(100_000);
+	}
+
+	return $log =~ m/$pat/;
+}


### PR DESCRIPTION
After a BDR node is parted or BDR is removed from local node, per-db and apply workers enter fail-and-restart cycles, IOW, the workers will fail in any of the subsequent operations with either ERROR or FATAL without unregistering themselves from BDR shared memory causing the workers to be restarted by postmaster. Typically, ERROR or FATAL in any bg worker will lead to proc_exit(1) and, the postmaster restarts bg worker with bgw_restart_time unless the bg worker exits with proc_exit(0).

For instance, if the per-db worker isn't unregistered it fails with "ERROR:  could not find node (...)".

Similarly, if the apply worker isn't unregistered it fails with "ERROR:  failed to find expected bdr.connections row ...".

A simple way to fix this is by checking node status in bdr_bgworker_init() i.e. before the worker gets to real business and, unregister it if node status is killed or no row exists for the node in bdr.bdr_nodes.

A TAP test verifying this use-case is added.

This issue has been identified here - https://github.com/aws/abba-pg-bdr/pull/38, thanks to @bdrouvotAWS.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
