### PR TITLE
Fix an assertion failure while setting bdr.do_not_replicate

### DIFF
--- a/bdr.h
+++ b/bdr.h
@@ -429,6 +429,8 @@ typedef struct BdrWorkerControl
 	bool		is_supervisor_restart;
 	/* Pause worker management (used in testing) */
 	bool		worker_management_paused;
+	/* Is local node restoring dump of remote node? */
+	bool		in_init_exec_dump_restore;
 	/* Latch for the supervisor worker */
 	Latch	   *supervisor_latch;
 	/* Array members, of size bdr_max_workers */

--- a/bdr_shmem.c
+++ b/bdr_shmem.c
@@ -175,6 +175,8 @@ bdr_worker_shmem_startup(void)
 		/* Worker management starts unpaused */
 		BdrWorkerCtl->worker_management_paused = false;
 
+		BdrWorkerCtl->in_init_exec_dump_restore = false;
+
 		/*
 		 * The postmaster keeps track of a generation number for BDR workers
 		 * and increments it at each restart.
@@ -331,6 +333,7 @@ bdr_worker_shmem_release(void)
 	LWLockAcquire(BdrWorkerCtl->lock, LW_EXCLUSIVE);
 	bdr_worker_slot->worker_pid = 0;
 	bdr_worker_slot->worker_proc = NULL;
+	BdrWorkerCtl->in_init_exec_dump_restore = false;
 	LWLockRelease(BdrWorkerCtl->lock);
 
 	bdr_worker_type = BDR_WORKER_EMPTY_SLOT;


### PR DESCRIPTION
The Assert(!IsBackgroundWorker); in bdr_do_not_replicate_check_hook fails when per-db is doing pg_restore on the local node. Because, the pg_restore executes a bunch of SQL statements from the pg_dump of the upstream node, and the SQL statements can generate query plans with parallel workers. Since every parallel worker loads GUC state
(ParallelWorkerMain->RestoreGUCState), and we have bdr.do_not_replicate set to on during pg_dump/pg_restore, the assertion fails.

Per commit  b21b2c8b203698d837daedff127007a9a550979b, intention of the bdr.do_not_replicate GUC is to not replicate changes from local node while it is initing from upstream node. The GUC is supposed to be used internally, and not by the users.

The assertion failure is seen when pgbench is run on an upstream node with '-i -s 100', and the local node is joined using bdr_group_join() to the upstream node.

To fix the assertion failure,  let's get rid of Assert(!IsBackgroundWorker);, and allow the GUC to be set only when the local node is in bdr_init_exec_dump_restore().


==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
