### PR TITLE
add bdr.log_min_messages GUC

### DIFF
--- a/bdr.c
+++ b/bdr.c
@@ -93,6 +93,7 @@ bool		bdr_discard_mismatched_row_attributes;
 bool		bdr_trace_replay;
 int			bdr_trace_ddl_locks_level;
 char	   *bdr_extra_apply_connection_options;
+int			bdr_log_min_messages = WARNING;
 
 PG_MODULE_MAGIC;
 
@@ -150,6 +151,60 @@ static const struct config_enum_entry bdr_trace_ddl_locks_level_options[] = {
 	{"none", DDL_LOCK_TRACE_NONE, false},
 	{NULL, 0, false}
 };
+
+/*
+ * bdr_error_severity --- get string representing elevel
+ */
+const char *
+bdr_error_severity(int elevel)
+{
+	const char *elevel_char;
+
+	switch (elevel)
+	{
+		case DEBUG1:
+			elevel_char = "DEBUG1";
+			break;
+		case DEBUG2:
+			elevel_char = "DEBUG2";
+			break;
+		case DEBUG3:
+			elevel_char = "DEBUG3";
+			break;
+		case DEBUG4:
+			elevel_char = "DEBUG4";
+			break;
+		case DEBUG5:
+			elevel_char = "DEBUG5";
+			break;
+		case LOG:
+			elevel_char = "LOG";
+			break;
+		case INFO:
+			elevel_char = "INFO";
+			break;
+		case NOTICE:
+			elevel_char = "NOTICE";
+			break;
+		case WARNING:
+			elevel_char = "WARNING";
+			break;
+		case ERROR:
+			elevel_char = "ERROR";
+			break;
+		case FATAL:
+			elevel_char = "FATAL";
+			break;
+		case PANIC:
+			elevel_char = "PANIC";
+			break;
+		default:
+			elevel_char = "???";
+			break;
+	}
+
+	return elevel_char;
+}
 
 void
 bdr_sigterm(SIGNAL_ARGS)
@@ -524,6 +579,10 @@ bdr_bgworker_init(uint32 worker_arg, BdrWorkerType worker_type)
 	SetConfigOption("synchronous_commit",
 					bdr_synchronous_commit ? "local" : "off",
 					PGC_BACKEND, PGC_S_OVERRIDE);	/* other context? */
+
+	/* set log_min_messages */
+	SetConfigOption("log_min_messages", bdr_error_severity(bdr_log_min_messages),
+					PGC_POSTMASTER, PGC_S_OVERRIDE);
 
 	if (worker_type == BDR_WORKER_APPLY)
 	{
@@ -981,6 +1040,16 @@ _PG_init(void)
 							   PGC_SIGHUP,
 							   0,
 							   NULL, NULL, NULL);
+
+	DefineCustomEnumVariable("bdr.log_min_messages",
+							 gettext_noop("log_min_messages for the bdr bgworkers."),
+							 NULL,
+							 &bdr_log_min_messages,
+							 WARNING,
+							 bdr_message_level_options,
+							 PGC_SIGHUP,
+							 GUC_SUPERUSER_ONLY,
+							 NULL, NULL, NULL);
 
 	EmitWarningsOnPlaceholders("bdr");
 

--- a/bdr.h
+++ b/bdr.h
@@ -97,6 +97,23 @@
 
 #define BDR_SECLABEL_PROVIDER "bdr"
 
+static const struct config_enum_entry bdr_message_level_options[] = {
+	{"debug5", DEBUG5, false},
+	{"debug4", DEBUG4, false},
+	{"debug3", DEBUG3, false},
+	{"debug2", DEBUG2, false},
+	{"debug1", DEBUG1, false},
+	{"debug", DEBUG2, true},
+	{"info", INFO, false},
+	{"notice", NOTICE, false},
+	{"warning", WARNING, false},
+	{"error", ERROR, false},
+	{"log", LOG, false},
+	{"fatal", FATAL, false},
+	{"panic", PANIC, false},
+	{NULL, 0, false}
+};
+
 /*
  * Don't include libpq here, msvc infrastructure requires linking to libpq
  * otherwise.
@@ -479,6 +496,7 @@ typedef struct BDRNodeInfo
 extern Oid	bdr_lookup_relid(const char *relname, Oid schema_oid);
 
 extern bool bdr_in_extension;
+extern int  bdr_log_min_messages;
 
 /* apply support */
 extern void bdr_fetch_sysid_via_node_id(RepOriginId node_id, BDRNodeId * out_nodeid);
@@ -749,6 +767,7 @@ extern BdrWorkerType bdr_worker_type;
 extern void bdr_make_my_nodeid(BDRNodeId * const node);
 extern void bdr_nodeid_cpy(BDRNodeId * const dest, const BDRNodeId * const src);
 extern bool bdr_nodeid_eq(const BDRNodeId * const left, const BDRNodeId * const right);
+extern const char *bdr_error_severity(int elevel);
 
 /*
  * sequencer support

--- a/bdr_apply.c
+++ b/bdr_apply.c
@@ -2650,6 +2650,9 @@ bdr_apply_work(PGconn *streamConn)
 		{
 			got_SIGHUP = false;
 			ProcessConfigFile(PGC_SIGHUP);
+			/* set log_min_messages */
+			SetConfigOption("log_min_messages", bdr_error_severity(bdr_log_min_messages),
+							PGC_POSTMASTER, PGC_S_OVERRIDE);
 		}
 
 		if (rc & WL_LATCH_SET)

--- a/bdr_perdb.c
+++ b/bdr_perdb.c
@@ -921,6 +921,9 @@ bdr_perdb_worker_main(Datum main_arg)
 		{
 			got_SIGHUP = false;
 			ProcessConfigFile(PGC_SIGHUP);
+			/* set log_min_messages */
+			SetConfigOption("log_min_messages", bdr_error_severity(bdr_log_min_messages),
+							PGC_POSTMASTER, PGC_S_OVERRIDE);
 		}
 
 		/* check whether we need to start new elections */

--- a/bdr_supervisor.c
+++ b/bdr_supervisor.c
@@ -179,6 +179,9 @@ bdr_register_perdb_worker(Oid dboid)
 		{
 			got_SIGHUP = false;
 			ProcessConfigFile(PGC_SIGHUP);
+			/* set log_min_messages */
+			SetConfigOption("log_min_messages", bdr_error_severity(bdr_log_min_messages),
+							PGC_POSTMASTER, PGC_S_OVERRIDE);
 		}
 
 		CHECK_FOR_INTERRUPTS();
@@ -573,6 +576,9 @@ bdr_supervisor_worker_main(Datum main_arg)
 		{
 			got_SIGHUP = false;
 			ProcessConfigFile(PGC_SIGHUP);
+			/* set log_min_messages */
+			SetConfigOption("log_min_messages", bdr_error_severity(bdr_log_min_messages),
+							PGC_POSTMASTER, PGC_S_OVERRIDE);
 		}
 
 		if (rc & WL_LATCH_SET)

--- a/doc/manual-conflicts.sgml
+++ b/doc/manual-conflicts.sgml
@@ -584,7 +584,7 @@
    Conflict logging to this table is only enabled when <xref
    linkend="guc-bdr-log-conflicts-to-table"> is
    <literal>true</literal>. BDR also logs conflicts to the PostgreSQL
-   log file if <literal>log_min_messages</literal> is <literal>LOG</literal>
+   log file if <literal>bdr.log_min_messages</literal> is <literal>LOG</literal>
    or lower, irrespective of the value of <literal>bdr.log_conflicts_to_table</literal>.
   </para>
 

--- a/doc/manual-settings.sgml
+++ b/doc/manual-settings.sgml
@@ -471,6 +471,20 @@
       </listitem>
      </varlistentry>
 
+     <varlistentry id="guc-bdr-log-min-messages" xreflabel="bdr.log_min_messages">
+      <term><varname>bdr.log_min_messages</varname> (<type>enum</type>)
+       <indexterm>
+        <primary><varname>bdr.log_min_messages</varname> configuration parameter</primary>
+       </indexterm>
+      </term>
+      <listitem>
+       <para>
+        Only affects BDR. Set the log_min_messages level for the BDR background
+        workers (default value is <literal>WARNING</literal>).
+       </para>
+      </listitem>
+     </varlistentry>
+
      <varlistentry id="guc-bdr-do-not-replicate" xreflabel="bdr.do_not_replicate">
       <term><varname>bdr.do_not_replicate</varname> (<type>boolean</type>)
        <indexterm>


### PR DESCRIPTION
The BDR bgworker are initialized without a username in BackgroundWorkerInitializeConnection().

One consequence is that the log_min_messages level inherited by the bgworkers is coming from:

 - the superuser's rolconfig that set log_min_messages (if any) that created the extension
 - the log_min_messages GUC value if the superuser that created the extension does not have a rolconfig that set log_min_messages to another value

For example, if the superuser that created the extension executes:

alter user <my_superuser> set log_min_messages = PANIC;

then, after a restart, the bgworkers would not display any messages in the logfile despite the log_min_messages set to WARNING in the postgresql.conf file.

This patch ensures that the new GUC "bdr.log_min_messages" will always been used as the log_min_messages level for the BDR bgworkers (even if the superuser that created the extension does have a rolconfig that set log_min_messages to another value).