### PR TITLE
Allow skip_ddl_replication and skip_ddl_locking to be set globally

### DIFF
--- a/bdr.c
+++ b/bdr.c
@@ -827,8 +827,8 @@ bdr_permit_unsafe_guc_check_hook(bool *newvalue, void **extra, GucSource source)
 		 */
 		ereport(WARNING,
 				(errmsg("unsafe BDR configuration options can not be set globally"),
-				 errdetail("The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options."),
-				 errhint("See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.")));
+				 errdetail("The bdr option bdr.permit_unsafe_ddl_commands should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options."),
+				 errhint("See the manual for information on this options Using it without care can break replication. Use it only with SET LOCAL inside a transaction.")));
 		return false;
 	}
 
@@ -952,13 +952,13 @@ _PG_init(void)
 							 bdr_permit_unsafe_guc_check_hook, NULL, NULL);
 
 	DefineCustomBoolVariable("bdr.skip_ddl_replication",
-							 "Internal. Set during local restore during init_replica only",
+							 "Skip DDL replication (will not be emmitted)",
 							 NULL,
 							 &bdr_skip_ddl_replication,
 							 false,
 							 PGC_SUSET,
 							 0,
-							 bdr_permit_unsafe_guc_check_hook, NULL, NULL);
+							 NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("bdr.skip_ddl_locking",
 							 "Don't acquire global DDL locks while performing DDL.",
@@ -967,7 +967,7 @@ _PG_init(void)
 							 false,
 							 PGC_SUSET,
 							 0,
-							 bdr_permit_unsafe_guc_check_hook, NULL, NULL);
+							 NULL, NULL, NULL);
 
 	DefineCustomIntVariable("bdr.default_apply_delay",
 							"default replication apply delay, can be overwritten per connection",

--- a/doc/manual-settings.sgml
+++ b/doc/manual-settings.sgml
@@ -454,11 +454,9 @@
       </term>
       <listitem>
        <para>
-        Only affects BDR. Skips replication of DDL changes
-        made in a session where this option is set to other systems.
-        This is primarily useful
-        for BDR internal use, but also can
-        be used for some intentional schema changes like adding a
+        Only affects BDR. Skips replication of DDL changes where this option is
+        set to other systems.  This is primarily useful for BDR internal use,
+        but also can be used for some intentional schema changes like adding a
         index only on some nodes. This option can be set at any time,
         but only by superusers.
        </para>

--- a/expected/guc.out
+++ b/expected/guc.out
@@ -1,21 +1,15 @@
 -- Disallow unsafe commands via ALTER SYSTEM SET, config file, ALTER DATABASE set, etc
+-- Should work
 ALTER SYSTEM
   SET bdr.skip_ddl_locking = on;
-WARNING:  unsafe BDR configuration options can not be set globally
-DETAIL:  The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
-HINT:  See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.
-ERROR:  invalid value for parameter "bdr.skip_ddl_locking": 1
 ALTER SYSTEM
   SET bdr.skip_ddl_replication = on;
-WARNING:  unsafe BDR configuration options can not be set globally
-DETAIL:  The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
-HINT:  See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.
-ERROR:  invalid value for parameter "bdr.skip_ddl_replication": 1
+-- Should fail
 ALTER SYSTEM
   SET bdr.permit_unsafe_ddl_commands = on;
 WARNING:  unsafe BDR configuration options can not be set globally
-DETAIL:  The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
-HINT:  See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.
+DETAIL:  The bdr option bdr.permit_unsafe_ddl_commands should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
+HINT:  See the manual for information on this options Using it without care can break replication. Use it only with SET LOCAL inside a transaction.
 ERROR:  invalid value for parameter "bdr.permit_unsafe_ddl_commands": 1
 -- The check for per-database settings only occurs when you're on that
 -- database, so we don't block the setting on another DB and the user
@@ -27,14 +21,14 @@ SELECT current_database();
 (1 row)
 
 ALTER DATABASE postgres
-  SET bdr.skip_ddl_locking = on;
+  SET bdr.permit_unsafe_ddl_commands = on;
 -- An ERROR setting a GUC doesn't stop the connection to the DB
 -- from succeeding though.
 \c postgres
 WARNING:  unsafe BDR configuration options can not be set globally
-DETAIL:  The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
-HINT:  See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.
-WARNING:  invalid value for parameter "bdr.skip_ddl_locking": 1
+DETAIL:  The bdr option bdr.permit_unsafe_ddl_commands should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
+HINT:  See the manual for information on this options Using it without care can break replication. Use it only with SET LOCAL inside a transaction.
+WARNING:  invalid value for parameter "bdr.permit_unsafe_ddl_commands": 1
 SELECT current_database();
  current_database 
 ------------------
@@ -42,7 +36,7 @@ SELECT current_database();
 (1 row)
 
 ALTER DATABASE postgres
-  RESET bdr.skip_ddl_locking;
+  RESET bdr.permit_unsafe_ddl_commands;
 \c postgres
 SELECT current_database();
  current_database 
@@ -60,7 +54,7 @@ SELECT current_database();
 -- This is true even when you ALTER the current database, so this
 -- commits fine, but switching back to the DB breaks:
 ALTER DATABASE regression
-  SET bdr.skip_ddl_locking = on;
+  SET bdr.permit_unsafe_ddl_commands = on;
 \c postgres
 SELECT current_database();
  current_database 
@@ -71,9 +65,9 @@ SELECT current_database();
 -- so this will report an error, but we'll still successfully connect to the DB.
 \c regression
 WARNING:  unsafe BDR configuration options can not be set globally
-DETAIL:  The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
-HINT:  See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.
-WARNING:  invalid value for parameter "bdr.skip_ddl_locking": 1
+DETAIL:  The bdr option bdr.permit_unsafe_ddl_commands should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
+HINT:  See the manual for information on this options Using it without care can break replication. Use it only with SET LOCAL inside a transaction.
+WARNING:  invalid value for parameter "bdr.permit_unsafe_ddl_commands": 1
 SELECT current_database();
  current_database 
 ------------------
@@ -82,7 +76,7 @@ SELECT current_database();
 
 -- and fix the GUC
 ALTER DATABASE regression
-  RESET bdr.skip_ddl_locking;
+  RESET bdr.permit_unsafe_ddl_commands;
 \c regression
 SELECT current_database();
  current_database 
@@ -93,18 +87,18 @@ SELECT current_database();
 -- Fixed.
 -- Explicit "off" is OK
 ALTER DATABASE regression
-  SET bdr.skip_ddl_locking = off;
+  SET bdr.permit_unsafe_ddl_commands = off;
 ALTER SYSTEM
-  SET bdr.skip_ddl_locking = off;
+  SET bdr.permit_unsafe_ddl_commands = off;
 ALTER SYSTEM
-  RESET bdr.skip_ddl_locking;
+  RESET bdr.permit_unsafe_ddl_commands;
 -- Per-user is OK
 ALTER USER super
-  SET bdr.skip_ddl_replication = on;
+  SET bdr.permit_unsafe_ddl_commands = on;
 ALTER USER super
-  SET bdr.skip_ddl_replication = off;
+  SET bdr.permit_unsafe_ddl_commands = off;
 ALTER USER super
-  RESET bdr.skip_ddl_replication;
+  RESET bdr.permit_unsafe_ddl_commands;
 -- Per session is OK
 SET bdr.permit_unsafe_ddl_commands = on;
 SET bdr.permit_unsafe_ddl_commands = off;

--- a/sql/guc.sql
+++ b/sql/guc.sql
@@ -1,9 +1,11 @@
 -- Disallow unsafe commands via ALTER SYSTEM SET, config file, ALTER DATABASE set, etc
 
+-- Should work
 ALTER SYSTEM
   SET bdr.skip_ddl_locking = on;
 ALTER SYSTEM
   SET bdr.skip_ddl_replication = on;
+-- Should fail
 ALTER SYSTEM
   SET bdr.permit_unsafe_ddl_commands = on;
 
@@ -13,7 +15,7 @@ ALTER SYSTEM
 SELECT current_database();
 
 ALTER DATABASE postgres
-  SET bdr.skip_ddl_locking = on;
+  SET bdr.permit_unsafe_ddl_commands = on;
 
 -- An ERROR setting a GUC doesn't stop the connection to the DB
 -- from succeeding though.
@@ -21,7 +23,7 @@ ALTER DATABASE postgres
 SELECT current_database();
 
 ALTER DATABASE postgres
-  RESET bdr.skip_ddl_locking;
+  RESET bdr.permit_unsafe_ddl_commands;
 
 \c postgres
 SELECT current_database();
@@ -32,7 +34,7 @@ SELECT current_database();
 -- This is true even when you ALTER the current database, so this
 -- commits fine, but switching back to the DB breaks:
 ALTER DATABASE regression
-  SET bdr.skip_ddl_locking = on;
+  SET bdr.permit_unsafe_ddl_commands = on;
 
 \c postgres
 SELECT current_database();
@@ -42,7 +44,7 @@ SELECT current_database();
 
 -- and fix the GUC
 ALTER DATABASE regression
-  RESET bdr.skip_ddl_locking;
+  RESET bdr.permit_unsafe_ddl_commands;
 
 \c regression
 SELECT current_database();
@@ -53,24 +55,24 @@ SELECT current_database();
 
 -- Explicit "off" is OK
 ALTER DATABASE regression
-  SET bdr.skip_ddl_locking = off;
+  SET bdr.permit_unsafe_ddl_commands = off;
 
 ALTER SYSTEM
-  SET bdr.skip_ddl_locking = off;
+  SET bdr.permit_unsafe_ddl_commands = off;
 
 ALTER SYSTEM
-  RESET bdr.skip_ddl_locking;
+  RESET bdr.permit_unsafe_ddl_commands;
 
 -- Per-user is OK
 
 ALTER USER super
-  SET bdr.skip_ddl_replication = on;
+  SET bdr.permit_unsafe_ddl_commands = on;
 
 ALTER USER super
-  SET bdr.skip_ddl_replication = off;
+  SET bdr.permit_unsafe_ddl_commands = off;
 
 ALTER USER super
-  RESET bdr.skip_ddl_replication;
+  RESET bdr.permit_unsafe_ddl_commands;
 
 -- Per session is OK
 SET bdr.permit_unsafe_ddl_commands = on;


### PR DESCRIPTION
This commit removes the ban of changing those GUCs at the system level. 
Default values are still the same and there is no behavioral changes (bdr_replicate_ddl_command() still does not take care of bdr.skip_ddl_replication).