### PR TITLE
fix delete on pg_depend in remove_bdr_from_local_node()

### DIFF
--- a/extsql/bdr--2.0.7.0.sql
+++ b/extsql/bdr--2.0.7.0.sql
@@ -1937,11 +1937,12 @@ BEGIN
     -- The trigger' dependency entry will be dangling because of how we dropped
     -- it.
     DELETE FROM pg_depend
-    WHERE classid = 'pg_trigger'::regclass
-      AND objid = _truncate_tg.tgobjid
-      AND (refclassid = 'pg_proc'::regclass AND refobjid = 'bdr.queue_truncate'::regproc)
+    WHERE classid = 'pg_trigger'::regclass AND
+      (objid = _truncate_tg.tgobjid
+       AND (refclassid = 'pg_proc'::regclass AND refobjid = 'bdr.queue_truncate'::regproc)
           OR
-          (refclassid = 'pg_class'::regclass AND refobjid = _truncate_tg.tgrelid);
+          (refclassid = 'pg_class'::regclass AND refobjid = _truncate_tg.tgrelid)
+	  );
 
   END LOOP;
 

--- a/t/120_bdr_remove_bdr_from_node.pl
+++ b/t/120_bdr_remove_bdr_from_node.pl
@@ -22,12 +22,21 @@ create_table_global_sequence( $node_a, 'test_table_sequence' );
 my $node_b = PostgreSQL::Test::Cluster->new('node_b');
 initandstart_logicaljoin_node( $node_b, $node_a );
 
+# Create a table foo
+$node_b->safe_psql( $bdr_test_dbname, "create table foo (a int primary key)" );
+
 # Part node_b before completely removing BDR
 part_nodes( [$node_b], $node_a );
 sleep(10);
 
 # Remove BDR from parted node
 bdr_remove( $node_b, 1 );
+
+# Remove the table foo
+$node_b->safe_psql( $bdr_test_dbname, "drop table foo" );
+
+# Re-create the table foo
+$node_b->safe_psql( $bdr_test_dbname, "create table foo (a int primary key)" );
 
 # Join a new node to first node using bdr_group_join
 my $node_c = PostgreSQL::Test::Cluster->new('node_c');


### PR DESCRIPTION
Too many entries were deleted in pg_depend leading to:

=# select bdr.remove_bdr_from_local_node();
NOTICE: removing BDR from node
INFO: BDR 1.0 global sequences not supported, nothing to convert NOTICE:  BDR removed from this node. You can now DROP EXTENSION bdr and, if this is the last BDR node on this PostgreSQL instance, remove bdr from shared_preload_libraries.

remove_bdr_from_local_node


(1 row)

=# drop table foo;
DROP TABLE

=# create table foo (a int primary key);
ERROR:  type "foo" already exists
HINT:  A relation has an associated type of the same name, so you must use a name that doesn't conflict with any existing type.

Note that dropping the relation before calling remove_bdr_from_local_node() does not produce the issue.

Updating 120_bdr_remove_bdr_from_node.pl to test the failing scenario (it would fail with the same error without the patch).

Without this fix a re-join would fail too (the table being re-created during the pg_restore stage).