### PR TITLE
Adressing new comments on the re-join behavior

### DIFF
--- a/bdr_perdb.c
+++ b/bdr_perdb.c
@@ -569,11 +569,12 @@ bdr_maintain_db_workers(void)
 #endif
 		char	   *roname = (char *) lfirst(lcroname);
 
-		if (RecoveryInProgress())
-				ereport(ERROR,
-						(errcode(ERRCODE_READ_ONLY_SQL_TRANSACTION),
-						errmsg("cannot manipulate replication origins during recovery")));
-
+		/*
+		 * Replication origins removal should not be allowed if
+		 * RecoveryInProgress() but we don't do this extra check as
+		 * RecoveryInProgress() is not possible here. Indeed, see the
+		 * RecoveryInProgress() test in bdr_supervisor_worker_main().
+		 */
 		elog(DEBUG1, "dropping replication origin %s due to node part", roname);
 #if PG_VERSION_NUM < 140000
 		roident = replorigin_by_name(roname, true);

--- a/doc/manual-node-management.sgml
+++ b/doc/manual-node-management.sgml
@@ -292,9 +292,9 @@
   </para>
    
   <para>
-    Use cases examples to rejoin: one does want to rejoin the same database
-    without having to re-create the whole instance. A node was down, associated
-    replication slots removed on the non parted node(s).
+    Typically, one wants to rejoin the same node to the same BDR group 1) To
+    avoid re-creating the whole database instance, 2) Associated replication
+    slots are dropped on the upstream node when the node goes down.
   </para>
 
  </sect1>

--- a/extsql/bdr--2.0.7.0.sql
+++ b/extsql/bdr--2.0.7.0.sql
@@ -2163,29 +2163,42 @@ LANGUAGE C;
 COMMENT ON FUNCTION wait_slot_confirm_lsn(name,pg_lsn) IS
 'Wait until slotname (or all slots, if null) has passed specified lsn (or current lsn, if null)';
 
-CREATE OR REPLACE FUNCTION bdr_dont_insert_or_delete_killed()
+CREATE OR REPLACE FUNCTION bdr_handle_rejoin()
   RETURNS trigger AS
 $$
 BEGIN
+-- Don't insert any rows on the re-joining node with a 'k' status.
+-- That way, duplicated keys on the primary key or node_name are avoided.
  IF NEW.node_status = 'k' THEN
 	RETURN NULL;
 
+-- Adding a new node (could be the re-joining node)
  ELSIF NEW.node_status = 'i' THEN
+-- We must ensure the delete done below on the other nodes matches the primary
+-- key on the re-joining node (so update the primary key accordingly).
+-- That way the delete can be propagated safely on the re-joining node.
+	UPDATE bdr.bdr_nodes SET node_sysid = NEW.node_sysid
+		WHERE node_status = 'k'
+		AND node_timeline = NEW.node_timeline
+		AND node_dboid = NEW.node_dboid
+		AND node_name = NEW.node_name;
+-- Delete the existing entry related to the re-joining node, so that it can be
+-- re-inserted with the right status.
 	DELETE FROM bdr.bdr_nodes
 	WHERE node_status = 'k'
-		  and node_sysid = NEW.node_sysid
-		  and node_timeline = NEW.node_timeline
-		  and node_dboid = NEW.node_dboid;
+		  AND node_sysid = NEW.node_sysid
+		  AND node_timeline = NEW.node_timeline
+		  AND node_dboid = NEW.node_dboid;
  END IF;
  RETURN NEW;
 END;$$
 LANGUAGE 'plpgsql';
 
-CREATE TRIGGER bdr_dont_insert_or_delete_killed_trigg
+CREATE TRIGGER bdr_handle_rejoin_trigg
 BEFORE INSERT
 ON bdr.bdr_nodes
 FOR EACH ROW
-EXECUTE PROCEDURE bdr_dont_insert_or_delete_killed();
+EXECUTE PROCEDURE bdr_handle_rejoin();
 
 RESET bdr.permit_unsafe_ddl_commands;
 RESET bdr.skip_ddl_replication;

--- a/t/046_rejoin_parted_nodes.pl
+++ b/t/046_rejoin_parted_nodes.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# Test unregistering per-db/apply worker after parting.
+# Test re-joining after parting and locally removed.
 use strict;
 use warnings;
 use lib 't/';


### PR DESCRIPTION
There is no need to check for RecoveryInProgress() before dropping the replication origins (as a similar check is already done in bdr_supervisor_worker_main()).

Renaming bdr_dont_insert_or_delete_killed to bdr_handle_rejoin.

The UPDATE added in bdr_handle_rejoin will be needed for the new "Allow BDR to generate its own node identifier" #75 PR coming soon.

Once the PR #75 gets in, a re-join not using the previous node name will keep the previous 'k' entry on the non parted nodes (while the re-joining one won't get it).

That should not be an issue at all, as 'k' entries are discarded in BDR anyway, but we can re-visit this approach if the logical rejoin feature gets used heavily and those remaining 'k' entries lead to confusion.