### PR TITLE
Add T_CallStmt handling in bdr_commandfilter()

### DIFF
--- a/bdr_commandfilter.c
+++ b/bdr_commandfilter.c
@@ -1329,6 +1329,9 @@ bdr_commandfilter(PlannedStmt *pstmt,
 		case T_GrantStmt:
 			break;
 
+		case T_CallStmt:
+			break;
+
 		default:
 
 			/*


### PR DESCRIPTION
without this fix, a CALL would produce:

call exec();
ERROR:  unrecognized node type: 353