### PR TITLE
Fix warning: implicit declaration of function 'unlink'

### DIFF
--- a/bdr.c
+++ b/bdr.c
@@ -15,6 +15,7 @@
 #include "postgres.h"
 
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include "bdr.h"
 #include "bdr_locks.h"


### PR DESCRIPTION
*Description of changes:*
Fix warning: implicit declaration of function 'unlink'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
