### PR TITLE
Fix flakiness in part_bdr.sql test

### DIFF
--- a/expected/part_bdr.out
+++ b/expected/part_bdr.out
@@ -158,14 +158,11 @@ SELECT bdr.bdr_is_active_in_db();
 
 -- Strip BDR from this node entirely and convert global sequences to local.
 BEGIN;
-SET LOCAL client_min_messages = 'notice';
+-- We silence notice messages here as some of them depend on when BDR workers
+-- on the parted node 'node-pg' are gone.
+SET LOCAL client_min_messages = 'ERROR';
 SELECT bdr.remove_bdr_from_local_node(true, true);
-WARNING:  forcing deletion of possibly active BDR node
-NOTICE:  node forced to parted state, now removing
-NOTICE:  removing BDR from node
 INFO:  BDR 1.0 global sequences not supported, nothing to convert
-NOTICE:  cannot remove BDR control file as BDR is still active on this node for database "postgres"
-NOTICE:  BDR removed from this node. You can now DROP EXTENSION bdr and, if this is the last BDR node on this PostgreSQL instance, remove bdr from shared_preload_libraries.
  remove_bdr_from_local_node 
 ----------------------------
  

--- a/sql/part_bdr.sql
+++ b/sql/part_bdr.sql
@@ -111,7 +111,9 @@ SELECT bdr.bdr_is_active_in_db();
 
 -- Strip BDR from this node entirely and convert global sequences to local.
 BEGIN;
-SET LOCAL client_min_messages = 'notice';
+-- We silence notice messages here as some of them depend on when BDR workers
+-- on the parted node 'node-pg' are gone.
+SET LOCAL client_min_messages = 'ERROR';
 SELECT bdr.remove_bdr_from_local_node(true, true);
 COMMIT;
 


### PR DESCRIPTION
CI member complained a sporadic failure (https://github.com/aws/abba-pg-bdr/actions/runs/5403052711/jobs/9815272593) in part_bdr.sql test in the notice messages generated by bdr.remove_bdr_from_local_node(). The falkiness is particularly due to a notice messages added by recent commit 1fe43d20a7ec1eb4f37e7b8f74e8fdd9abc9e5d5 (Allow BDR to generate its own node identifier). While removing BDR node identifier, we check if BDR is active on any of the databases in the node, if so, we generate a notice message and exit without removing the BDR node id, otherwise we remove. In part_bdr.sql, BDR is removed for 'node-pg' first and at the end, BDR is removed from the local node, and sometimes the per-db worker pertaining to 'node-pg' goes away before we call bdr.remove_bdr_from_local_node() and the expected notice message "cannot remove BDR control file as BDR is still active ...." isn't seen. This is due to the per-db workers get unregistered in the background after the part of the node.

To fix this flakiness, let's slience the notice messages that bdr.remove_bdr_from_local_node() generates. These notice messages are mostly informational and users will get them anyway when they use the function themselves.

Because fixing this issue in other ways like ensuring per-db worker related to parted node goes away with a wait loop looking for "select count(*) = 0 from bdr.bdr_get_workers_info() where node = 'node-pg';" won't work. Becuase, the per-db worker goes away completely/unregisters after the local node gets its part status which it self is unreliable to test in sql file, see the comment in part_bdr.sql that starts with "It is unsafe/incorrect to expect the parted node to ....".

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
