### PR TITLE
Upload only log files to artifactory in CI on failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
           name: test-artifact-${{ matrix.os }}-${{ matrix.version }}
           path: |
             bdr/regression.diffs
-            bdr/tmp_check
+            bdr/tmp_check/log
             # Upload bdr_pgbench.sh results
             $GITHUB_WORKSPACE/pgbench_results
           retention-days: 1


### PR DESCRIPTION
CI workflow currently uploads entire tmp_check directory upon failures making the artifactory sizes to be more 1 GB. Most of it are temporary pgdata directories created for each of the TAP test which are unnecessary. What we are interested in for analysis of any failures is the server logs and regression tests logs which are avaiable under tmp_check/log. Therefore, upload only the logs (a few MBs in size). This also reduces the upload artifactory step time in CI.

=============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
