### PR TITLE
Fix sporadic failure in 046_rejoin_parted_nodes

### DIFF
--- a/t/046_rejoin_parted_nodes.pl
+++ b/t/046_rejoin_parted_nodes.pl
@@ -23,7 +23,7 @@ part_nodes([$node_0], $node_1);
 check_part_statuses([$node_0], $node_1);
 
 # Remove BDR from the parted node
-$node_0->safe_psql($bdr_test_dbname, "select bdr.remove_bdr_from_local_node()");
+$node_0->safe_psql($bdr_test_dbname, "select bdr.remove_bdr_from_local_node(true)");
 
 #
 # Use case 1: a parted node without relations that already exist on the other 
@@ -62,7 +62,7 @@ part_nodes([$node_0], $node_1);
 check_part_statuses([$node_0], $node_1);
 
 # Remove BDR from the parted node
-$node_0->safe_psql($bdr_test_dbname, "select bdr.remove_bdr_from_local_node()");
+$node_0->safe_psql($bdr_test_dbname, "select bdr.remove_bdr_from_local_node(true)");
 
 # re-join the parted node
 my $logstart_0 = get_log_size($node_0);


### PR DESCRIPTION
Time to time the test fails due to:

LOG:  statement: select bdr.remove_bdr_from_local_node()
ERROR:  this BDR node might still be active, not removing
CONTEXT:  PL/pgSQL function bdr.remove_bdr_from_local_node(boolean,boolean) line 28 at RAISE

This is due to check_part_statuses() not checking the 'k' status for the parted node, as per its comment:

```
It is unsafe/incorrect to expect the parted node to know it’s parted and
have a ‘k’ state. Sometimes it will, sometimes it won’t, it depends on a
race between the parting node terminating its connections and it
receiving notification of its own parting. That’s a bit of a wart in BDR,
but won’t be fixed in 2.0 and is actually very hard to truly “fix” in a
distributed system. So we allow the local node status to be ‘k’ or ‘r’.
```

So this patch uses the force option in bdr.remove_bdr_from_local_node() to avoid the error mentioned above.
