### PR TITLE
Fix sporadic failure in 045_unregister_workers_after_part.pl

### DIFF
--- a/t/045_unregister_workers_after_part.pl
+++ b/t/045_unregister_workers_after_part.pl
@@ -32,7 +32,7 @@ my $result = wait_for_worker_to_unregister($node_0,
 ok($result, "unregistering apply worker on node_0 is detected");
 
 # Remove BDR from the parted node
-$node_0->safe_psql($bdr_test_dbname, "select bdr.remove_bdr_from_local_node()");
+$node_0->safe_psql($bdr_test_dbname, "select bdr.remove_bdr_from_local_node(true)");
 
 # per-db worker must be unregistered on a node with BDR removed
 $result = wait_for_worker_to_unregister($node_0,


### PR DESCRIPTION
Sporadically a test case in 045_unregister_workers_after_part.pl fails as follows:

not ok 19 - unregistering apply worker on node_0 is detected

ERROR:  this BDR node might still be active, not removing bdr.remove_bdr_from_local_node(boolean,boolean) line 28 at RAISE'

Issue and fix is similar to a recent commit 0c19cc799ea7.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
