### PR TITLE
Change default behavior and scope for DDL replication and DDL locking

### DIFF
--- a/bdr.h
+++ b/bdr.h
@@ -415,6 +415,7 @@ extern bool bdr_permit_ddl_locking;
 extern bool bdr_permit_unsafe_commands;
 extern bool bdr_skip_ddl_locking;
 extern bool bdr_skip_ddl_replication;
+extern bool prev_bdr_skip_ddl_replication;
 extern bool bdr_do_not_replicate;
 extern bool bdr_discard_mismatched_row_attributes;
 extern int	bdr_max_ddl_lock_delay;

--- a/bdr_apply.c
+++ b/bdr_apply.c
@@ -843,9 +843,9 @@ process_remote_insert(StringInfo s)
 
 	check_bdr_wakeups(rel);
 
-	/* execute DDL if insertion was into the ddl command queue */
-	if (RelationGetRelid(rel->rel) == QueuedDDLCommandsRelid ||
-		RelationGetRelid(rel->rel) == QueuedDropsRelid)
+	/* execute DDL if insertion was into the ddl command queue and if ddl replication is wanted */
+	if (!prev_bdr_skip_ddl_replication  && (RelationGetRelid(rel->rel) == QueuedDDLCommandsRelid ||
+		RelationGetRelid(rel->rel) == QueuedDropsRelid))
 	{
 		HeapTuple	ht;
 		LockRelId	lockid = rel->rel->rd_lockInfo.lockRelId;

--- a/bdr_pgbench.sh
+++ b/bdr_pgbench.sh
@@ -93,6 +93,10 @@ shared_preload_libraries = 'bdr'
 track_commit_timestamp = on
 wal_level = 'logical'
 port=7432
+bdr.permit_unsafe_ddl_commands = false
+bdr.skip_ddl_replication = false
+bdr.skip_ddl_locking = false
+bdr.permit_ddl_locking = true
 EOF
 
 # Start pg instance

--- a/bdr_regress.conf
+++ b/bdr_regress.conf
@@ -12,3 +12,8 @@ bdrtest.readdb1 = 'regression'
 bdrtest.readdb2 = 'postgres'
 bdrtest.writedb1 = 'regression'
 bdrtest.writedb2 = 'postgres'
+
+bdr.permit_unsafe_ddl_commands = false
+bdr.skip_ddl_replication = false
+bdr.skip_ddl_locking = false
+bdr.permit_ddl_locking = true

--- a/expected/ddl_enable_ddl.out
+++ b/expected/ddl_enable_ddl.out
@@ -3,16 +3,16 @@ CREATE TABLE should_fail ( id integer );
 ERROR:  global DDL locking attempt rejected by configuration
 DETAIL:  bdr.permit_ddl_locking is false and the attempted command would require the global lock to be acquired. Command rejected.
 HINT:  See the 'DDL replication' chapter of the documentation.
-SET bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 CREATE TABLE create_ok (id integer);
 SET bdr.permit_ddl_locking = false;
 ALTER TABLE create_ok ADD COLUMN alter_should_fail text;
 ERROR:  global DDL locking attempt rejected by configuration
 DETAIL:  bdr.permit_ddl_locking is false and the attempted command would require the global lock to be acquired. Command rejected.
 HINT:  See the 'DDL replication' chapter of the documentation.
-SET bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 DROP TABLE create_ok;
 -- Now for the rest of the DDL tests, presume they're allowed,
 -- otherwise they'll get pointlessly verbose.
-ALTER DATABASE regression SET bdr.permit_ddl_locking = true;
-ALTER DATABASE postgres SET bdr.permit_ddl_locking = true;
+ALTER DATABASE regression RESET bdr.permit_ddl_locking;
+ALTER DATABASE postgres RESET bdr.permit_ddl_locking;

--- a/expected/ddl_fn/ddl_enable_ddl.out
+++ b/expected/ddl_fn/ddl_enable_ddl.out
@@ -4,7 +4,7 @@ ERROR:  global DDL locking attempt rejected by configuration
 DETAIL:  bdr.permit_ddl_locking is false and the attempted command would require the global lock to be acquired. Command rejected.
 HINT:  See the 'DDL replication' chapter of the documentation.
 CONTEXT:  during DDL replay of ddl statement:  CREATE TABLE public.should_fail ( id integer ) 
-SET bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($DDL$ CREATE TABLE public.create_ok (id integer) $DDL$);
  bdr_replicate_ddl_command 
 ---------------------------
@@ -17,7 +17,7 @@ ERROR:  global DDL locking attempt rejected by configuration
 DETAIL:  bdr.permit_ddl_locking is false and the attempted command would require the global lock to be acquired. Command rejected.
 HINT:  See the 'DDL replication' chapter of the documentation.
 CONTEXT:  during DDL replay of ddl statement:  ALTER TABLE public.create_ok ADD COLUMN alter_should_fail text 
-SET bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($DDL$ DROP TABLE public.create_ok $DDL$);
  bdr_replicate_ddl_command 
 ---------------------------
@@ -26,13 +26,13 @@ SELECT bdr.bdr_replicate_ddl_command($DDL$ DROP TABLE public.create_ok $DDL$);
 
 -- Now for the rest of the DDL tests, presume they're allowed,
 -- otherwise they'll get pointlessly verbose.
-SELECT bdr.bdr_replicate_ddl_command($DDL$ ALTER DATABASE regression SET bdr.permit_ddl_locking = true $DDL$);
+SELECT bdr.bdr_replicate_ddl_command($DDL$ ALTER DATABASE regression RESET bdr.permit_ddl_locking $DDL$);
  bdr_replicate_ddl_command 
 ---------------------------
  
 (1 row)
 
-SELECT bdr.bdr_replicate_ddl_command($DDL$ ALTER DATABASE postgres SET bdr.permit_ddl_locking = true $DDL$);
+SELECT bdr.bdr_replicate_ddl_command($DDL$ ALTER DATABASE postgres RESET bdr.permit_ddl_locking $DDL$);
  bdr_replicate_ddl_command 
 ---------------------------
  

--- a/expected/dml_basic.out
+++ b/expected/dml_basic.out
@@ -3,7 +3,7 @@ SELECT * FROM public.bdr_regress_variables()
 \gset
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	CREATE TABLE public.basic_dml (
 		id serial primary key,
@@ -174,7 +174,7 @@ SELECT id, other, data, something FROM basic_dml ORDER BY id;
 
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$DROP TABLE public.basic_dml;$$);
  bdr_replicate_ddl_command 
 ---------------------------

--- a/expected/dml_contrib.out
+++ b/expected/dml_contrib.out
@@ -3,7 +3,7 @@ SELECT * FROM public.bdr_regress_variables()
 \gset
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	-- XXX: BDR prevents replicating commands inside create/alter/drop
 	-- extension, it asserts (Assert(!bdr_in_extension);) that in
@@ -157,7 +157,7 @@ SELECT id, fixed, variable FROM contrib_dml ORDER BY id;
 
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$DROP TABLE public.contrib_dml;$$);
  bdr_replicate_ddl_command 
 ---------------------------

--- a/expected/dml_delete_pk.out
+++ b/expected/dml_delete_pk.out
@@ -3,7 +3,7 @@ SELECT * FROM public.bdr_regress_variables()
 \gset
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	CREATE TABLE public.test (
 		id TEXT,
@@ -83,7 +83,7 @@ SELECT id FROM test ORDER BY ts;
 
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$DROP TABLE public.test;$$);
  bdr_replicate_ddl_command 
 ---------------------------

--- a/expected/dml_extended.out
+++ b/expected/dml_extended.out
@@ -3,7 +3,7 @@ SELECT * FROM public.bdr_regress_variables()
 \gset
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	CREATE TABLE public.tst_one_array (
 		a INTEGER PRIMARY KEY,
@@ -1380,7 +1380,7 @@ SELECT a, b, c FROM tst_range_array ORDER BY a;
 
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	DROP TABLE public.tst_one_array;
 	DROP TABLE public.tst_arrays;

--- a/expected/dml_missing_pk.out
+++ b/expected/dml_missing_pk.out
@@ -3,7 +3,7 @@ SELECT * FROM public.bdr_regress_variables()
 \gset
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 -- Suppress some CONTEXT msgs that vary by version
 SET LOCAL client_min_messages = warning;
 SELECT bdr.bdr_replicate_ddl_command($$
@@ -153,7 +153,7 @@ UPDATE pg_class
 SET relname = 'bdr_missing_pk'
 WHERE relname = 'bdr_missing_pk_renamed';
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SET LOCAL client_min_messages = warning;
 SELECT bdr.bdr_replicate_ddl_command($$DROP TABLE public.bdr_missing_pk CASCADE;$$);
  bdr_replicate_ddl_command 

--- a/expected/dml_toasted.out
+++ b/expected/dml_toasted.out
@@ -3,7 +3,7 @@ SELECT * FROM public.bdr_regress_variables()
 \gset
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	CREATE TABLE public.toasted (
 		id serial primary key,
@@ -66,7 +66,7 @@ SELECT * FROM toasted ORDER BY id;
 
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$DROP TABLE public.toasted;$$);
  bdr_replicate_ddl_command 
 ---------------------------

--- a/expected/guc.out
+++ b/expected/guc.out
@@ -1,22 +1,10 @@
--- Disallow unsafe commands via ALTER SYSTEM SET, config file, ALTER DATABASE set, etc
+-- Allow commands via ALTER SYSTEM SET, config file, ALTER DATABASE set, etc
 ALTER SYSTEM
   SET bdr.skip_ddl_locking = on;
-WARNING:  unsafe BDR configuration options can not be set globally
-DETAIL:  The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
-HINT:  See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.
-ERROR:  invalid value for parameter "bdr.skip_ddl_locking": 1
 ALTER SYSTEM
   SET bdr.skip_ddl_replication = on;
-WARNING:  unsafe BDR configuration options can not be set globally
-DETAIL:  The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
-HINT:  See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.
-ERROR:  invalid value for parameter "bdr.skip_ddl_replication": 1
 ALTER SYSTEM
   SET bdr.permit_unsafe_ddl_commands = on;
-WARNING:  unsafe BDR configuration options can not be set globally
-DETAIL:  The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
-HINT:  See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.
-ERROR:  invalid value for parameter "bdr.permit_unsafe_ddl_commands": 1
 -- The check for per-database settings only occurs when you're on that
 -- database, so we don't block the setting on another DB and the user
 -- has to undo it later.
@@ -26,15 +14,19 @@ SELECT current_database();
  regression
 (1 row)
 
+-- Should be ok
 ALTER DATABASE postgres
   SET bdr.skip_ddl_locking = on;
+-- Should fail
+ALTER DATABASE postgres
+  SET bdr.skip_ddl_locking = off;
+WARNING:  unsafe BDR configuration options can not be disabled locally
+DETAIL:  The bdr options bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be disabled globally.
+HINT:  See the manual for information on these options. Using them without care can break replication.
+ERROR:  invalid value for parameter "bdr.skip_ddl_locking": 0
 -- An ERROR setting a GUC doesn't stop the connection to the DB
 -- from succeeding though.
 \c postgres
-WARNING:  unsafe BDR configuration options can not be set globally
-DETAIL:  The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
-HINT:  See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.
-WARNING:  invalid value for parameter "bdr.skip_ddl_locking": 1
 SELECT current_database();
  current_database 
 ------------------
@@ -60,7 +52,11 @@ SELECT current_database();
 -- This is true even when you ALTER the current database, so this
 -- commits fine, but switching back to the DB breaks:
 ALTER DATABASE regression
-  SET bdr.skip_ddl_locking = on;
+  SET bdr.skip_ddl_replication = off;
+WARNING:  unsafe BDR configuration options can not be disabled locally
+DETAIL:  The bdr options bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be disabled globally.
+HINT:  See the manual for information on these options. Using them without care can break replication.
+ERROR:  invalid value for parameter "bdr.skip_ddl_replication": 0
 \c postgres
 SELECT current_database();
  current_database 
@@ -70,10 +66,6 @@ SELECT current_database();
 
 -- so this will report an error, but we'll still successfully connect to the DB.
 \c regression
-WARNING:  unsafe BDR configuration options can not be set globally
-DETAIL:  The bdr options bdr.permit_unsafe_ddl_commands, bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be enabled with a SET or SET LOCAL command in a SQL session or set in client connection options.
-HINT:  See the manual for information on these options. Using them without care can break replication. Use them only with SET LOCAL inside a transaction.
-WARNING:  invalid value for parameter "bdr.skip_ddl_locking": 1
 SELECT current_database();
  current_database 
 ------------------
@@ -91,9 +83,14 @@ SELECT current_database();
 (1 row)
 
 -- Fixed.
--- Explicit "off" is OK
+-- Explicit "off" is Not OK
 ALTER DATABASE regression
   SET bdr.skip_ddl_locking = off;
+WARNING:  unsafe BDR configuration options can not be disabled locally
+DETAIL:  The bdr options bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be disabled globally.
+HINT:  See the manual for information on these options. Using them without care can break replication.
+ERROR:  invalid value for parameter "bdr.skip_ddl_locking": 0
+-- Unless at the system level
 ALTER SYSTEM
   SET bdr.skip_ddl_locking = off;
 ALTER SYSTEM
@@ -101,11 +98,38 @@ ALTER SYSTEM
 -- Per-user is OK
 ALTER USER super
   SET bdr.skip_ddl_replication = on;
+-- Unless not permitted
 ALTER USER super
   SET bdr.skip_ddl_replication = off;
+WARNING:  unsafe BDR configuration options can not be disabled locally
+DETAIL:  The bdr options bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be disabled globally.
+HINT:  See the manual for information on these options. Using them without care can break replication.
+ERROR:  invalid value for parameter "bdr.skip_ddl_replication": 0
 ALTER USER super
   RESET bdr.skip_ddl_replication;
 -- Per session is OK
 SET bdr.permit_unsafe_ddl_commands = on;
 SET bdr.permit_unsafe_ddl_commands = off;
+SET bdr.skip_ddl_replication = on;
+SET bdr.skip_ddl_locking = on;
+SET bdr.permit_ddl_locking = off;
+-- Unless values are not permitted
+SET bdr.skip_ddl_replication = off;
+WARNING:  unsafe BDR configuration options can not be disabled locally
+DETAIL:  The bdr options bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be disabled globally.
+HINT:  See the manual for information on these options. Using them without care can break replication.
+ERROR:  invalid value for parameter "bdr.skip_ddl_replication": 0
+SET bdr.skip_ddl_locking = off;
+WARNING:  unsafe BDR configuration options can not be disabled locally
+DETAIL:  The bdr options bdr.skip_ddl_locking and bdr.skip_ddl_replication should only be disabled globally.
+HINT:  See the manual for information on these options. Using them without care can break replication.
+ERROR:  invalid value for parameter "bdr.skip_ddl_locking": 0
+SET bdr.permit_ddl_locking = on;
+WARNING:  unsafe BDR configuration options can not be enabled locally
+DETAIL:  The bdr options bdr.permit_ddl_locking should only be enabled globally.
+HINT:  See the manual for information on these options. Using them without care can break replication.
+ERROR:  invalid value for parameter "bdr.permit_ddl_locking": 1
 RESET bdr.permit_unsafe_ddl_commands;
+RESET bdr.skip_ddl_replication;;
+RESET bdr.skip_ddl_locking;
+RESET bdr.permit_ddl_locking;

--- a/md/bdr-configuration-variables.md
+++ b/md/bdr-configuration-variables.md
@@ -151,8 +151,8 @@ server restart to take effect.
 
     Only affects BDR. Prevents acquisiton of the the global DDL lock
     when executing DDL statement. This is mainly used internally, but
-    can also be useful in other cases. This option can be set at any
-    time, but only by superusers.
+    can also be useful in other cases. This option can be set globally at any
+    time, or enabled locally (at the session level) but only by superusers.
 
     ::: WARNING
       **Warning**
@@ -173,11 +173,10 @@ server restart to take effect.
 
 `bdr.skip_ddl_replication` (`boolean`)
 
-    Only affects BDR. Skips replication of DDL changes made in a session
-    where this option is set to other systems. This is primarily useful
-    for BDR internal use, but also can be used for some intentional
-    schema changes like adding a index only on some nodes. This option
-    can be set at any time, but only by superusers.
+    Only affects BDR. Skips replication and apply of DDL changes.
+    This is set to on by default so that a BDR node bevahes as a non BDR one by
+    default.  This option can be changed globally or enabled locally
+    (at the session level) but only by superusers.
 
     ::: WARNING
       **Warning**

--- a/md/ddl-replication-advice.md
+++ b/md/ddl-replication-advice.md
@@ -153,16 +153,8 @@ or
      
 ```
 
-or set it globally in `postgresql.conf`. Then when you intend
-to perform disruptive DDL, explicitly permit it:
+or set it globally in `postgresql.conf`.
 
-``` PROGRAMLISTING
-BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
--- Do your schema changes here
-COMMIT;
-     
-```
 
 
 

--- a/md/ddl-replication.md
+++ b/md/ddl-replication.md
@@ -37,9 +37,6 @@ schemas to other connected nodes. That makes it easier to make certain
 DDL changes without worrying about having to manually distribute the DDL
 change to all nodes and ensure they\'re consistent.
 
-There is not currently an option to turn off DDL replication and apply
-DDL manually instead.
-
 Before doing DDL on [BDR], read [Section
 8.1](ddl-replication-advice.md) and [Statement specific DDL
 replication concerns](ddl-replication-statements.md).

--- a/sql/ddl_enable_ddl.sql
+++ b/sql/ddl_enable_ddl.sql
@@ -1,16 +1,16 @@
 SET bdr.permit_ddl_locking = false;
 CREATE TABLE should_fail ( id integer );
 
-SET bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 CREATE TABLE create_ok (id integer);
 
 SET bdr.permit_ddl_locking = false;
 ALTER TABLE create_ok ADD COLUMN alter_should_fail text;
 
-SET bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 DROP TABLE create_ok;
 
 -- Now for the rest of the DDL tests, presume they're allowed,
 -- otherwise they'll get pointlessly verbose.
-ALTER DATABASE regression SET bdr.permit_ddl_locking = true;
-ALTER DATABASE postgres SET bdr.permit_ddl_locking = true;
+ALTER DATABASE regression RESET bdr.permit_ddl_locking;
+ALTER DATABASE postgres RESET bdr.permit_ddl_locking;

--- a/sql/ddl_fn/ddl_enable_ddl.sql
+++ b/sql/ddl_fn/ddl_enable_ddl.sql
@@ -1,16 +1,16 @@
 SET bdr.permit_ddl_locking = false;
 SELECT bdr.bdr_replicate_ddl_command($DDL$ CREATE TABLE public.should_fail ( id integer ) $DDL$);
 
-SET bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($DDL$ CREATE TABLE public.create_ok (id integer) $DDL$);
 
 SET bdr.permit_ddl_locking = false;
 SELECT bdr.bdr_replicate_ddl_command($DDL$ ALTER TABLE public.create_ok ADD COLUMN alter_should_fail text $DDL$);
 
-SET bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($DDL$ DROP TABLE public.create_ok $DDL$);
 
 -- Now for the rest of the DDL tests, presume they're allowed,
 -- otherwise they'll get pointlessly verbose.
-SELECT bdr.bdr_replicate_ddl_command($DDL$ ALTER DATABASE regression SET bdr.permit_ddl_locking = true $DDL$);
-SELECT bdr.bdr_replicate_ddl_command($DDL$ ALTER DATABASE postgres SET bdr.permit_ddl_locking = true $DDL$);
+SELECT bdr.bdr_replicate_ddl_command($DDL$ ALTER DATABASE regression RESET bdr.permit_ddl_locking $DDL$);
+SELECT bdr.bdr_replicate_ddl_command($DDL$ ALTER DATABASE postgres RESET bdr.permit_ddl_locking $DDL$);

--- a/sql/dml_basic.sql
+++ b/sql/dml_basic.sql
@@ -5,7 +5,7 @@ SELECT * FROM public.bdr_regress_variables()
 \c :writedb1
 
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	CREATE TABLE public.basic_dml (
 		id serial primary key,
@@ -83,6 +83,6 @@ SELECT id, other, data, something FROM basic_dml ORDER BY id;
 
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$DROP TABLE public.basic_dml;$$);
 COMMIT;

--- a/sql/dml_contrib.sql
+++ b/sql/dml_contrib.sql
@@ -5,7 +5,7 @@ SELECT * FROM public.bdr_regress_variables()
 \c :writedb1
 
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	-- XXX: BDR prevents replicating commands inside create/alter/drop
 	-- extension, it asserts (Assert(!bdr_in_extension);) that in
@@ -76,6 +76,6 @@ SELECT id, fixed, variable FROM contrib_dml ORDER BY id;
 
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$DROP TABLE public.contrib_dml;$$);
 COMMIT;

--- a/sql/dml_delete_pk.sql
+++ b/sql/dml_delete_pk.sql
@@ -5,7 +5,7 @@ SELECT * FROM public.bdr_regress_variables()
 \c :writedb1
 
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	CREATE TABLE public.test (
 		id TEXT,
@@ -43,6 +43,6 @@ SELECT id FROM test ORDER BY ts;
 
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$DROP TABLE public.test;$$);
 COMMIT;

--- a/sql/dml_extended.sql
+++ b/sql/dml_extended.sql
@@ -5,7 +5,7 @@ SELECT * FROM public.bdr_regress_variables()
 \c :writedb1
 
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	CREATE TABLE public.tst_one_array (
 		a INTEGER PRIMARY KEY,
@@ -549,7 +549,7 @@ SELECT a, b, c FROM tst_range_array ORDER BY a;
 
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	DROP TABLE public.tst_one_array;
 	DROP TABLE public.tst_arrays;

--- a/sql/dml_missing_pk.sql
+++ b/sql/dml_missing_pk.sql
@@ -5,7 +5,7 @@ SELECT * FROM public.bdr_regress_variables()
 \c :writedb1
 
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 -- Suppress some CONTEXT msgs that vary by version
 SET LOCAL client_min_messages = warning;
 SELECT bdr.bdr_replicate_ddl_command($$
@@ -98,7 +98,7 @@ SET relname = 'bdr_missing_pk'
 WHERE relname = 'bdr_missing_pk_renamed';
 
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SET LOCAL client_min_messages = warning;
 SELECT bdr.bdr_replicate_ddl_command($$DROP TABLE public.bdr_missing_pk CASCADE;$$);
 COMMIT;

--- a/sql/dml_toasted.sql
+++ b/sql/dml_toasted.sql
@@ -5,7 +5,7 @@ SELECT * FROM public.bdr_regress_variables()
 \c :writedb1
 
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$
 	CREATE TABLE public.toasted (
 		id serial primary key,
@@ -46,6 +46,6 @@ SELECT * FROM toasted ORDER BY id;
 
 \c :writedb1
 BEGIN;
-SET LOCAL bdr.permit_ddl_locking = true;
+RESET bdr.permit_ddl_locking;
 SELECT bdr.bdr_replicate_ddl_command($$DROP TABLE public.toasted;$$);
 COMMIT;

--- a/t/020_standalone.pl
+++ b/t/020_standalone.pl
@@ -21,6 +21,9 @@ wal_level = logical
 track_commit_timestamp = on
 shared_preload_libraries = 'bdr'
 });
+
+bdr_update_default_postgresql_conf($node_a);
+
 $node_a->start;
 
 $node_a->safe_psql('postgres', qq{CREATE DATABASE $bdr_test_dbname;});

--- a/t/utils/nodemanagement.pm
+++ b/t/utils/nodemanagement.pm
@@ -50,6 +50,7 @@ use vars qw(@ISA @EXPORT @EXPORT_OK);
     wait_acquire_ddl_lock
     cancel_ddl_lock
     release_ddl_lock
+	bdr_update_default_postgresql_conf
     );
 
 # For use by other modules, but need not appear in the default namespace of
@@ -142,6 +143,19 @@ sub initandstart_node {
 
 }
 
+sub bdr_update_default_postgresql_conf {
+	my ($node) = shift;
+
+	$node->append_conf(
+		'postgresql.conf', q{
+			bdr.permit_unsafe_ddl_commands = false
+			bdr.skip_ddl_replication = false
+			bdr.skip_ddl_locking = false
+			bdr.permit_ddl_locking = true
+            }
+    );
+}
+
 # Edit postgresql.conf with required parameters for BDR
 sub bdr_update_postgresql_conf {
     my ($node) = shift;
@@ -163,6 +177,8 @@ sub bdr_update_postgresql_conf {
             log_line_prefix = '%m %p %d [%a] %c:%l (%v:%t) '
             }
     );
+
+	bdr_update_default_postgresql_conf($node);
 }
 
 sub _create_db_and_exts {


### PR DESCRIPTION
This commit change the default values for:

bdr.permit_ddl_locking from true to false
bdr.permit_unsafe_ddl_commands from false to true
bdr.skip_ddl_replication from false to true
bdr.skip_ddl_locking from false to true

so that by default a BDR enabled instance behaves like a non BDR one as far DDL (and "global" locking) are concerned.

Except for bdr.permit_unsafe_ddl_commands, changing those default values can only be done globally (aka editing the postgresql.conf file or using ALTER SYSTEM).

One can still SET those variables locally but only if the new value is the default one mentioned above.

bdr.skip_ddl_replication now also impacts DDL replay (it was only impacting the one that executed the DDL previously).
