### PR TITLE
Fixing T_AlterExtensionContentsStmt behavior

### DIFF
--- a/bdr_commandfilter.c
+++ b/bdr_commandfilter.c
@@ -1420,8 +1420,9 @@ done:
 			/* FALLTHROUGH */
 		case T_CreateExtensionStmt:
 		case T_AlterExtensionStmt:
-		case T_AlterExtensionContentsStmt:
 			Assert(!bdr_in_extension);
+			/* FALLTHROUGH */
+		case T_AlterExtensionContentsStmt:
 			bdr_in_extension = true;
 			entered_extension = true;
 			break;
@@ -1485,7 +1486,8 @@ done:
 	if (entered_extension)
 	{
 		Assert(bdr_in_extension);
-		bdr_in_extension = false;
+		if (nodeTag(parsetree) != T_AlterExtensionContentsStmt)
+			bdr_in_extension = false;
 	}
 
 	if (incremented_nestlevel)


### PR DESCRIPTION
bdr_commandfilter() was missing the fact that T_AlterExtensionContentsStmt can be launched within an extension sql file leading to wrong assertion.

That does fix https://github.com/aws/abba-pg-bdr/issues/101, indeed pg_stat_statements--1.6--1.7.sql does contain T_AlterExtensionContentsStmt with

```
ALTER EXTENSION pg_stat_statements DROP FUNCTION pg_stat_statements_reset();
```