### PR TITLE
Remove insert bdr_connections_changed() in internal_node_join

### DIFF
--- a/extsql/bdr--2.0.7.0.sql
+++ b/extsql/bdr--2.0.7.0.sql
@@ -614,14 +614,6 @@ BEGIN
 
     -- Schedule the apply worker launch for commit time
     PERFORM bdr.bdr_connections_changed();
-
-    -- and ensure the apply worker is launched on other nodes when this
-    -- transaction replicates there, too.
-    INSERT INTO bdr.bdr_queued_commands
-    (lsn, queued_at, perpetrator, command_tag, command)
-    VALUES
-    (pg_current_wal_insert_lsn(), current_timestamp, current_user,
-    'SELECT', 'SELECT bdr.bdr_connections_changed()');
 END;
 $body$;
 


### PR DESCRIPTION
The insert of "SELECT bdr.bdr_connections_changed()" into the bdr.bdr_queued_commands is not needed into internal_node_join().

The reason is, that during a node join a new row will be inserted into the bdr_nodes table leading to process_remote_insert being executed: and so, check_bdr_wakeups() on the "bdr_nodes table" and so bdr_connections_changed() too.

It also explains why a join was working fine even with skip ddl replication enabled (see "join works fine even if skip_ddl_replication is set to true" in https://github.com/aws/abba-pg-bdr/issues/108).