### PR TITLE
Fix assertion failure with nested ALTER/DROP EXTENSION queries

### DIFF
--- a/expected/dml_contrib.out
+++ b/expected/dml_contrib.out
@@ -5,15 +5,7 @@ SELECT * FROM public.bdr_regress_variables()
 BEGIN;
 RESET bdr.skip_ddl_replication;
 SELECT bdr.bdr_replicate_ddl_command($$
-	-- XXX: BDR prevents replicating commands inside create/alter/drop
-	-- extension, it asserts (Assert(!bdr_in_extension);) that in
-	-- bdr_commandfilter function. But, cube extension version 1.4 has two
-	-- ALTER EXTENSION ... DROP FUNCTION statements which cause the
-	-- assertion to fail. Therefore, we choose to install a previous version
-	-- of cube extension, which is okay for the sake of these tests. However,
-	-- we might have to change this when upstream postgres removes version 1.3
-	-- completely.
-	CREATE EXTENSION IF NOT EXISTS cube SCHEMA public VERSION '1.3';
+	CREATE EXTENSION IF NOT EXISTS cube SCHEMA public;
 	CREATE EXTENSION IF NOT EXISTS hstore SCHEMA public;
 
 	CREATE TABLE public.contrib_dml (

--- a/sql/dml_contrib.sql
+++ b/sql/dml_contrib.sql
@@ -7,15 +7,7 @@ SELECT * FROM public.bdr_regress_variables()
 BEGIN;
 RESET bdr.skip_ddl_replication;
 SELECT bdr.bdr_replicate_ddl_command($$
-	-- XXX: BDR prevents replicating commands inside create/alter/drop
-	-- extension, it asserts (Assert(!bdr_in_extension);) that in
-	-- bdr_commandfilter function. But, cube extension version 1.4 has two
-	-- ALTER EXTENSION ... DROP FUNCTION statements which cause the
-	-- assertion to fail. Therefore, we choose to install a previous version
-	-- of cube extension, which is okay for the sake of these tests. However,
-	-- we might have to change this when upstream postgres removes version 1.3
-	-- completely.
-	CREATE EXTENSION IF NOT EXISTS cube SCHEMA public VERSION '1.3';
+	CREATE EXTENSION IF NOT EXISTS cube SCHEMA public;
 	CREATE EXTENSION IF NOT EXISTS hstore SCHEMA public;
 
 	CREATE TABLE public.contrib_dml (


### PR DESCRIPTION
When nested ALTER EXTESION .. DROP FUNCTION/DROP EXTENSION queries specified in an extension script file,
Assert(!bdr_in_extension); in bdr_commandfilter() fails.

When we are there with bdr_in_extension true, it means that we entered create/alter/drop extension previously, but the extension script file is having one or more of ALTER EXTESION .. DROP FUNCTION/DROP EXTENSION statements. However, postgres fails with "ERROR: nested CREATE EXTENSION is not supported" or "ERROR: nested ALTER EXTENSION is not supported" if create extension or alter extension respectively is specified in an extension script file. We don't do anything fancy here for BDR, other than ensuring the alter extension .. drop function/ drop extension statements within extension script file aren't replicated, which will be taken care by the flag bdr_in_extension that's set to true previously.

To fix the assertion failure issue, we remove the assertion and use if (!bdr_in_extension) to set things.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
