### PR TITLE
Add meaningful messages at LOG level for some proc_exit(1)

### DIFF
--- a/bdr_apply.c
+++ b/bdr_apply.c
@@ -2582,13 +2582,13 @@ bdr_apply_reload_config()
 		/* If the DSN or replication sets changed we must restart */
 		if (strcmp(bdr_apply_config->dsn, new_apply_config->dsn) != 0)
 		{
-			elog(DEBUG1, "apply worker exiting to apply new DSN configuration");
+			elog(LOG, "apply worker exiting to apply new DSN configuration");
 			proc_exit(1);
 		}
 
 		if (strcmp(bdr_apply_config->replication_sets, new_apply_config->replication_sets) != 0)
 		{
-			elog(DEBUG1, "apply worker exiting to apply new replication set configuration");
+			elog(LOG, "apply worker exiting to apply new replication set configuration");
 			proc_exit(1);
 		}
 

--- a/bdr_supervisor.c
+++ b/bdr_supervisor.c
@@ -391,7 +391,7 @@ bdr_get_supervisordb_oid(bool missingok)
 		 * We'll get relaunched soon, so just die rather than having a
 		 * wait-and-test loop here
 		 */
-		elog(DEBUG1, "exiting because BDR supervisor database " BDR_SUPERVISOR_DBNAME " does not yet exist");
+		elog(LOG, "exiting because BDR supervisor database " BDR_SUPERVISOR_DBNAME " does not yet exist");
 		proc_exit(1);
 	}
 
@@ -518,7 +518,7 @@ bdr_supervisor_worker_main(Datum main_arg)
 
 		BdrWorkerCtl->is_supervisor_restart = true;
 
-		elog(DEBUG1, "BDR supervisor restarting to connect to '%s' DB",
+		elog(LOG, "BDR supervisor restarting to connect to '%s' DB for shared catalog access",
 			 BDR_SUPERVISOR_DBNAME);
 		proc_exit(1);
 	}
@@ -532,7 +532,7 @@ bdr_supervisor_worker_main(Datum main_arg)
 	BdrWorkerCtl->supervisor_latch = &MyProc->procLatch;
 	LWLockRelease(BdrWorkerCtl->lock);
 
-	elog(DEBUG1, "BDR supervisor connected to DB " BDR_SUPERVISOR_DBNAME);
+	elog(LOG, "BDR supervisor restarted and connected to DB " BDR_SUPERVISOR_DBNAME);
 
 	SetConfigOption("application_name", "bdr supervisor", PGC_USERSET, PGC_S_SESSION);
 


### PR DESCRIPTION
Replace DEBUG2 messages by LOG ones before some proc_exit(1) so that one can understand what's going on by reading the logfile (by default).