### PR TITLE
Make pglogical and bdr working together

### DIFF
--- a/bdr.c
+++ b/bdr.c
@@ -116,7 +116,7 @@ int			bdr_init_node_parallel_jobs;
 PG_MODULE_MAGIC;
 
 #if PG_VERSION_NUM >= 150000
-shmem_request_hook_type prev_shmem_request_hook = NULL;
+shmem_request_hook_type bdr_prev_shmem_request_hook = NULL;
 #endif
 
 void		_PG_init(void);
@@ -1164,7 +1164,7 @@ _PG_init(void)
 		 * information and hook into shmem initialization.
 		 */
 #if PG_VERSION_NUM >= 150000
-		prev_shmem_request_hook = shmem_request_hook;
+		bdr_prev_shmem_request_hook = shmem_request_hook;
 		shmem_request_hook = bdr_shmem_init;
 #else
 		bdr_shmem_init();

--- a/bdr.h
+++ b/bdr.h
@@ -126,7 +126,7 @@ struct ScanKeyData;				/* from access/skey.h for ScanKey */
 enum LockTupleMode;				/* from access/heapam.h */
 
 #if PG_VERSION_NUM >= 150000
-extern shmem_request_hook_type prev_shmem_request_hook;
+extern shmem_request_hook_type bdr_prev_shmem_request_hook;
 #endif
 
 /*

--- a/bdr_shmem.c
+++ b/bdr_shmem.c
@@ -49,8 +49,8 @@ void
 bdr_shmem_init(void)
 {
 #if PG_VERSION_NUM >= 150000
-	if (prev_shmem_request_hook)
-		prev_shmem_request_hook();
+	if (bdr_prev_shmem_request_hook)
+		bdr_prev_shmem_request_hook();
 #endif
 	/* can never have more worker slots than processes to register them */
 	bdr_max_workers = max_worker_processes + max_wal_senders;


### PR DESCRIPTION
Prior to this commit, pglogical and bdr were using the same

```
extern shmem_request_hook_type prev_shmem_request_hook
```

leading to infinite loop on bdr_shmem_init() like this:

```
Breakpoint 1, bdr_shmem_init () at bdr_shmem.c:53
53              if (prev_shmem_request_hook)
(gdb) bt
0  bdr_shmem_init () at bdr_shmem.c:53
1  0x00007f100d6834ae in bdr_shmem_init () at bdr_shmem.c:54
2  0x00007f100d6834ae in bdr_shmem_init () at bdr_shmem.c:54
3  0x00007f100d6834ae in bdr_shmem_init () at bdr_shmem.c:54
4  0x00007f100d592021 in pglogical_worker_shmem_init () at pglogical_worker.c:708
5  0x000055bbea4a6094 in process_shmem_requests () at miscinit.c:1717
6  0x000055bbea1dc7f7 in PostmasterMain (argc=3, argv=0x55bbebf29260) at postmaster.c:1048
7  0x000055bbea0d0ceb in main (argc=3, argv=0x55bbebf29260) at main.c:202
```

and the engine was not able to start without giving any clues:

```
$ pg_ctl -D $PGDATA  start
waiting for server to start....2023-07-13 08:21:59.540 UTC [1840045] DEBUG:  registering background worker "logical replication launcher"
2023-07-13 08:21:59.544 UTC [1840045] DEBUG:  registering background worker "bdr supervisor"
2023-07-13 08:21:59.544 UTC [1840045] DEBUG:  loaded library "bdr"
2023-07-13 08:21:59.545 UTC [1840045] DEBUG:  registering background worker "pglogical supervisor"
2023-07-13 08:21:59.545 UTC [1840045] DEBUG:  loaded library "pglogical"
 stopped waiting
pg_ctl: could not start server
Examine the log output.
```

Renaming prev_shmem_request_hook to bdr_prev_shmem_request_hook fix the issue.

While at it make a few changes to t/034_pglogical.pl to make it work:

```
$ make prove_check PROVE_TESTS="t/034_pglogical.pl"
Building against PostgreSQL 15
t/034_pglogical.pl .. ok
All tests successful.