### PR TITLE
Add developer-friendly compiler options to CI build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
             cd bdr
             PATH=$GITHUB_WORKSPACE/postgres/inst/bin:"$PATH"
             sh configure
-            make -j4 all install
+            make PROFILE="-Wall -Wmissing-prototypes -Werror" -j4 all install
 
       - name: Run BDR core tests
         run: |


### PR DESCRIPTION
Add PROFILE="-Wall -Wmissing-prototypes -Werror" while building BDR code in CI. This helps developers to detect warnings early and fix them (with -Werror all warnings are converted to errors, that's intentional to act upon fixing such compiler warnings).

We have seen more than 3 instances the warnings were detected after code changes went in.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
