### PR TITLE
Decouple BDR code from btree_gist

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -127,10 +127,10 @@ $(info Building against PostgreSQL $(MAJORVERSION))
 export PG_CONFIG
 export PATH
 
-# Modules such as pg_trgm, cube and hstore are used by BDR in tests, i.e. if
-# they aren't available the tests start to fail. Therefore, it is not required
-# to error out.
-REQUIRED_TEST_EXTENSIONS = pg_trgm cube hstore
+# Modules such as btree_gist, cube, hstore and pg_trgm are used by BDR in
+# tests, i.e. if they aren't available the tests start to fail. Therefore,
+# it is not required to error out.
+REQUIRED_TEST_EXTENSIONS = btree_gist cube hstore pg_trgm
 
 BDR_DUMP_DIR := compat/$(BDR_PG_MAJORVERSION)/pg_dump
 BDR_DUMP_OBJS = $(BDR_DUMP_DIR)/pg_dump.o \

--- a/bdr.c
+++ b/bdr.c
@@ -971,14 +971,6 @@ _PG_init(void)
 					 errmsg("bdr requires \"track_commit_timestamp\" to be enabled")));
 	}
 
-	/*
-	 * Force btree_gist to be loaded - its absolutely not required at this
-	 * point, but since it's required for BDR to be used it's much easier to
-	 * debug if we error out during start than failing during background
-	 * worker initialization.
-	 */
-	load_external_function("btree_gist", "gbtreekey_in", true, NULL);
-
 	/* XXX: make it changeable at SIGHUP? */
 	DefineCustomBoolVariable("bdr.synchronous_commit",
 							 "bdr specific synchronous commit value",
@@ -1206,7 +1198,6 @@ void
 bdr_maintain_schema(bool update_extensions)
 {
 	Relation	extrel;
-	Oid			btree_gist_oid;
 	Oid			bdr_oid;
 	Oid			schema_oid;
 
@@ -1222,23 +1213,13 @@ bdr_maintain_schema(bool update_extensions)
 	/* make sure we're operating without other bdr workers interfering */
 	extrel = table_open(ExtensionRelationId, ShareUpdateExclusiveLock);
 
-	btree_gist_oid = get_extension_oid("btree_gist", true);
 	bdr_oid = get_extension_oid("bdr", true);
-
-	if (btree_gist_oid == InvalidOid)
-		elog(ERROR, "btree_gist is required by BDR but not installed in the current database");
-
 	if (bdr_oid == InvalidOid)
 		elog(ERROR, "bdr extension is not installed in the current database");
 
 	if (update_extensions)
 	{
 		AlterExtensionStmt alter_stmt;
-
-		/* TODO: only do this if necessary */
-		alter_stmt.options = NIL;
-		alter_stmt.extname = (char *) "btree_gist";
-		ExecAlterExtensionStmt(NULL, &alter_stmt);
 
 		/* TODO: only do this if necessary */
 		alter_stmt.options = NIL;

--- a/bdr.control
+++ b/bdr.control
@@ -3,5 +3,4 @@ comment = 'Bi-directional replication for PostgreSQL'
 default_version = '2.0.7.0'
 module_pathname = '$libdir/bdr'
 relocatable = false
-requires = btree_gist
 schema = pg_catalog

--- a/bdr_init_copy.c
+++ b/bdr_init_copy.c
@@ -1469,8 +1469,6 @@ bdr_node_start(PGconn *conn, char *node_name, char *remote_connstr,
 	PGresult   *res;
 
 	/* Install required extensions if needed. */
-	if (!extension_exists(conn, "btree_gist"))
-		install_extension(conn, "btree_gist");
 	if (!extension_exists(conn, "bdr"))
 		install_extension(conn, "bdr");
 

--- a/bdr_init_replica.c
+++ b/bdr_init_replica.c
@@ -1050,8 +1050,8 @@ bdr_init_replica(BDRNodeInfo * local_node)
 				 *
 				 * To avoid that We need to be able to run pg_restore --clean,
 				 * and that needs a way to exclude the bdr schema, the bdr
-				 * extension, and their dependencies like plpgsql and
-				 * btree_gist. (TODO patch pg_restore for that)
+				 * extension, and their dependencies like plpgsql. (TODO patch
+				 * pg_restore for that)
 				 */
 				ereport(ERROR,
 						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),

--- a/bdr_pgbench.sh
+++ b/bdr_pgbench.sh
@@ -71,7 +71,7 @@ echo "Building pg source code at $PGSRC"
 cd $PGSRC
 sh configure --prefix=$PWD/inst/ CFLAGS="-O2" > $RESULTS/install.log && make -j8 install > $RESULTS/install.log 2>&1
 
-# Install contrib modules required for BDR
+# Install contrib modules required for BDR tests
 make -C contrib/btree_gist install
 make -C contrib/cube install
 make -C contrib/hstore install
@@ -102,13 +102,13 @@ $PGBIN/pg_ctl -D $PGBIN/data -l $RESULTS/server.log start
 # BDR-cize nodes
 echo "BDR-cizing node $WHALE"
 $PGBIN/psql -h $WHALE_H -p $WHALE_P postgres -c "CREATE DATABASE $WHALE_DB" >> $RESULTS/check.log 2>&1
-$PGBIN/psql -h $WHALE_H -p $WHALE_P $WHALE_DB -c "CREATE EXTENSION bdr CASCADE" >> $RESULTS/check.log 2>&1
+$PGBIN/psql -h $WHALE_H -p $WHALE_P $WHALE_DB -c "CREATE EXTENSION bdr" >> $RESULTS/check.log 2>&1
 $PGBIN/psql -h $WHALE_H -p $WHALE_P $WHALE_DB -c "SELECT bdr.bdr_create_group(local_node_name := '$WHALE', node_external_dsn := 'dbname=$WHALE_DB host=$WHALE_H port=$WHALE_P')" >> $RESULTS/check.log 2>&1
 $PGBIN/psql -h $WHALE_H -p $WHALE_P $WHALE_DB -c "SELECT bdr.bdr_wait_for_node_ready()" >> $RESULTS/check.log 2>&1
 
 echo "BDR-cizing node $PANDA"
 $PGBIN/psql -h $PANDA_H -p $PANDA_P postgres -c "CREATE DATABASE $PANDA_DB" >> $RESULTS/check.log 2>&1
-$PGBIN/psql -h $PANDA_H -p $PANDA_P $PANDA_DB -c "CREATE EXTENSION bdr CASCADE" >> $RESULTS/check.log 2>&1
+$PGBIN/psql -h $PANDA_H -p $PANDA_P $PANDA_DB -c "CREATE EXTENSION bdr" >> $RESULTS/check.log 2>&1
 $PGBIN/psql -h $PANDA_H -p $PANDA_P $PANDA_DB -c "SELECT bdr.bdr_join_group(local_node_name := '$PANDA', node_external_dsn := 'dbname=$PANDA_DB host=$PANDA_H port=$PANDA_P', join_using_dsn := 'dbname=$WHALE_DB host=$WHALE_H port=$WHALE_P')" >> $RESULTS/check.log 2>&1
 $PGBIN/psql -h $PANDA_H -p $PANDA_P $PANDA_DB -c "SELECT bdr.bdr_wait_for_node_ready()" >> $RESULTS/check.log 2>&1
 

--- a/md/quickstart-enabling.md
+++ b/md/quickstart-enabling.md
@@ -11,7 +11,6 @@ postgreSQL superuser, create the extensions necessary for
 ``` PROGRAMLISTING
     psql -p 5598 -U postgres bdrdemo
 
-       CREATE EXTENSION btree_gist;
        CREATE EXTENSION bdr;
     
 ```
@@ -44,7 +43,6 @@ necessary for [BDR]:
 ``` PROGRAMLISTING
     psql -p 5599 -U postgres bdrdemo
 
-       CREATE EXTENSION btree_gist;
        CREATE EXTENSION bdr;
     
 ```

--- a/t/020_standalone.pl
+++ b/t/020_standalone.pl
@@ -26,7 +26,6 @@ bdr.skip_ddl_replication = false
 $node_a->start;
 
 $node_a->safe_psql('postgres', qq{CREATE DATABASE $bdr_test_dbname;});
-$node_a->safe_psql($bdr_test_dbname, q{CREATE EXTENSION btree_gist;});
 $node_a->safe_psql($bdr_test_dbname, q{CREATE EXTENSION bdr;});
 
 is($node_a->safe_psql($bdr_test_dbname, 'SELECT bdr.bdr_is_active_in_db()'), 'f',

--- a/t/120_bdr_remove_bdr_from_node.pl
+++ b/t/120_bdr_remove_bdr_from_node.pl
@@ -68,7 +68,6 @@ sub bdr_remove {
         );
     }
     $node->safe_psql( $bdr_test_dbname, "drop extension bdr cascade" );
-    $node->safe_psql( $bdr_test_dbname, "drop extension btree_gist" );
 
     # Alter table to use local sequence
     $node->safe_psql( $bdr_test_dbname,

--- a/t/utils/nodemanagement.pm
+++ b/t/utils/nodemanagement.pm
@@ -170,7 +170,6 @@ sub _create_db_and_exts {
     my $node = shift;
 
     $node->safe_psql( 'postgres', qq{CREATE DATABASE $bdr_test_dbname;} );
-    $node->safe_psql( $bdr_test_dbname,    q{CREATE EXTENSION btree_gist;} );
     $node->safe_psql( $bdr_test_dbname,    q{CREATE EXTENSION bdr;} );
 
 }


### PR DESCRIPTION
Historically, BDR (C) code has checks spread across to verify if btree_gist extension is installed and loadable. However, no part of BDR C code is using it except the SQL and TAP tests that use it for creating GIST indexes and exclusion constraints. There seems to be no point in BDR internally having code checks for btree_gist availability. If btree_gist isn't available, currently, BDR doesn't let your postgres instance to start and fails with "FATAL:  could not access file "btree_gist": No such file ...".

When btree_gist is used by BDR for only tests, we can call it out as an extended needed to run BDR tests just like pg_trgm, cube, hstore.

Looked at historic BDR commits to see if it btree_gist was ever used by BDR internally, found no such evidence. If at all, one wants to use btree_gist for indexes or exclusion constraints with BDR, they can install the btree_gist extension, and start using it without BDR having to maintain internal checks.

This commit removes all BDR C code related to btree_gist.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
