### PR TITLE
Fix for error "No such file or directory" and speedup checkpoint

### DIFF
--- a/bdr_init_copy.c
+++ b/bdr_init_copy.c
@@ -906,11 +906,10 @@ remove_unwanted_files(char *data_dir)
 		 * Postgres commit cc8d41511721 changed this function input parameters
 		 * in version 12.
 		 */
-		snprintf(path, MAXPGPATH, "%s/pg_logical/", data_dir);
 #if PG_VERSION_NUM < 120000
-		fsync_fname(path, true, progname);
+		fsync_parent_path(path, progname);
 #else
-		fsync_fname(path, true);
+		fsync_parent_path(path);
 #endif
 
 		print_msg(VERBOSITY_VERBOSE, "Removed BDR control file.\n");


### PR DESCRIPTION
Add --checkpoint=fast for pg_basebackup
Fix bdr_init_copy: error: could not open file "$PGDATA/pg_logical/bdr_control": No such file or directory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
