### PR TITLE
Remove unneeded remote node info fetching code

### DIFF
--- a/bdr_remotecalls.c
+++ b/bdr_remotecalls.c
@@ -301,8 +301,6 @@ bdr_get_remote_nodeinfo_internal(PGconn *conn, struct remote_node_info *ri)
 		elog(WARNING, "parsed BDR version %d from string %s != returned BDR version %d",
 			 parsed_version_num, remote_bdr_version_str, ri->version_num);
 
-	PQclear(res);
-
 	res = PQexec(conn, "SELECT datcollate, datctype FROM pg_database "
 					   "WHERE datname = current_database();");
 


### PR DESCRIPTION
This commit removes unneeded remote node info fetching code in bdr_get_remote_nodeinfo_internal(). There is some old version specific code which determines first if remote node has certain BDR version related functions. This was needed then to support upgrading from an old BDR version to new BDR version that introduced these BDR functions. But, now, the new BDR version that we're releasing with has all of these functions available, and we have a clear message going in for someone wanting to move and use the latest BDR version - remove traces of old BDR versions (if any) on nodes joining and start afresh with the latest version.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
