### PR TITLE
Fix pg_upgrade issue with a replication origin function

### DIFF
--- a/bdr.c
+++ b/bdr.c
@@ -141,6 +141,7 @@ PGDLLEXPORT Datum bdr_is_active_in_db(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum bdr_generate_node_identifier(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum bdr_get_node_identifier(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum bdr_remove_node_identifier(PG_FUNCTION_ARGS);
+PGDLLIMPORT extern Datum bdr_xact_replication_origin(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(bdr_apply_pause);
 PG_FUNCTION_INFO_V1(bdr_apply_resume);
@@ -161,6 +162,7 @@ PG_FUNCTION_INFO_V1(bdr_is_active_in_db);
 PG_FUNCTION_INFO_V1(bdr_generate_node_identifier);
 PG_FUNCTION_INFO_V1(bdr_get_node_identifier);
 PG_FUNCTION_INFO_V1(bdr_remove_node_identifier);
+PG_FUNCTION_INFO_V1(bdr_xact_replication_origin);
 
 static int	bdr_get_worker_pid_byid(const BDRNodeId * const nodeid, BdrWorkerType worker_type);
 
@@ -1812,22 +1814,17 @@ bdr_is_active_in_db(PG_FUNCTION_ARGS)
 	PG_RETURN_BOOL(bdr_is_bdr_activated_db(MyDatabaseId));
 }
 
-/* Postgres commit b1e48bbe64a4 introduced this function in version 14. */
-#if PG_VERSION_NUM < 140000
-PG_FUNCTION_INFO_V1(pg_xact_commit_timestamp_origin);
-
 Datum
-pg_xact_commit_timestamp_origin(PG_FUNCTION_ARGS)
+bdr_xact_replication_origin(PG_FUNCTION_ARGS)
 {
 	TransactionId xid = PG_GETARG_UINT32(0);
-	RepOriginId data = 0;
+	RepOriginId data;
 	TimestampTz ts;
 
 	TransactionIdGetCommitTsData(xid, &ts, &data);
 
 	PG_RETURN_INT32((int32) data);
 }
-#endif
 
 /*
  * Postgres commit 9e98583898c3/a19e5cee635d introduced this function in

--- a/bdr_executor.c
+++ b/bdr_executor.c
@@ -18,6 +18,7 @@
 
 #include "bdr.h"
 
+#include "access/heapam.h"
 #include "access/xact.h"
 
 #include "catalog/indexing.h"

--- a/extsql/bdr--2.0.7.0.sql
+++ b/extsql/bdr--2.0.7.0.sql
@@ -1772,24 +1772,15 @@ REVOKE ALL ON FUNCTION bdr_acquire_global_lock(text) FROM public;
 COMMENT ON FUNCTION bdr_acquire_global_lock(text) IS
 'Acquire bdr global lock ("ddl lock") in specified mode';
 
--- b1e48bbe64a4 introduced in PG14
-DO $$BEGIN
-  PERFORM 1 FROM pg_proc WHERE proname = 'pg_xact_commit_timestamp_origin';
-  IF FOUND THEN
-    CREATE FUNCTION bdr_get_transaction_replorigin(xid) RETURNS oid
-    AS 'SELECT roident FROM pg_catalog.pg_xact_commit_timestamp_origin($1);'
-    LANGUAGE SQL;
-  ELSE
-    CREATE FUNCTION bdr_get_transaction_replorigin(xid) RETURNS oid
-    AS 'MODULE_PATHNAME','pg_xact_commit_timestamp_origin'
-    LANGUAGE C;
-  END IF;
-END;$$;
+CREATE FUNCTION bdr_xact_replication_origin(xid)
+RETURNS oid
+AS 'MODULE_PATHNAME','bdr_xact_replication_origin'
+LANGUAGE C;
 
-REVOKE ALL ON FUNCTION bdr_get_transaction_replorigin(xid) FROM public;
+REVOKE ALL ON FUNCTION bdr_xact_replication_origin(xid) FROM public;
 
-COMMENT ON FUNCTION bdr_get_transaction_replorigin(xid) IS
-'Get the replication origin id for a given transaction if still known';
+COMMENT ON FUNCTION bdr_xact_replication_origin(xid) IS
+'Get replication origin id for a given transaction';
 
 --
 -- When upgrading an existing cluster we must assign node sequence IDs.

--- a/md/functions.md
+++ b/md/functions.md
@@ -63,7 +63,7 @@ In the latest version of BDR, some of the user-facing extension SQL functions or
 | queue_truncate                  | bdr_queue_truncate                     |
 | node_status_from_char           | bdr_node_status_from_char              |
 | node_status_to_char             | bdr_node_status_to_char                |
-| get_transaction_replorigin      | bdr_get_transaction_replorigin         |
+| get_transaction_replorigin      | bdr_xact_replication_origin            |
 | upgrade_to_200                  | bdr_assign_seq_ids_post_upgrade        |
 | global_seq_nextval              | bdr_snowflake_id_nextval               |
 | global_seq_nextval_test         | _bdr_snowflake_id_nextval_private      |

--- a/t/030_syncrep.pl
+++ b/t/030_syncrep.pl
@@ -249,7 +249,7 @@ node_d|node_d];
 my $query = q[
 select coalesce(node_name, bdr.bdr_get_local_node_name()) AS origin_node_name, x
 from t
-cross join lateral bdr.bdr_get_transaction_replorigin(xmin) ro(originid)
+cross join lateral bdr.bdr_xact_replication_origin(xmin) ro(originid)
 left join pg_replication_origin on (roident = originid)
 cross join lateral bdr.bdr_parse_replident_name(roname)
 left join bdr.bdr_nodes on (remote_sysid, remote_timeline, remote_dboid) = (node_sysid, node_timeline, node_dboid)

--- a/t/035_duprows.pl
+++ b/t/035_duprows.pl
@@ -23,7 +23,7 @@ use Test::More;
 my $query = q[
 select coalesce(node_name, bdr.bdr_get_local_node_name()) AS origin_node_name, x
 from t
-cross join lateral bdr.bdr_get_transaction_replorigin(xmin) ro(originid)
+cross join lateral bdr.bdr_xact_replication_origin(xmin) ro(originid)
 left join pg_replication_origin on (roident = originid)
 cross join lateral bdr.bdr_parse_replident_name(roname)
 left join bdr.bdr_nodes on (remote_sysid, remote_timeline, remote_dboid) = (node_sysid, node_timeline, node_dboid)


### PR DESCRIPTION
BDR defined a wrapper to get replication origin id of a given transaction. The wrapper was defined in SQL when
pg_catalog.pg_xact_commit_timestamp_origin available (for PG versions >= 14), otherwise defined in C by BDR (for PG versions < 14). This was causing pg_restore to fail when a BDR node is upgraded from say PG11 to PG15.

To fix the issue, we define the function to get replication origin of a transaction in C within BDR for all of the versions, so while upgrading the function exists in BDR shared library.

While here, the function is renamed to bdr_xact_replication_origin to match with Postgres replication origin related functions.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
