### PR TITLE
Fixing compilation error when using --enable-cassert and -Werror=maybe-uninitialized

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
             cd bdr
             PATH=$GITHUB_WORKSPACE/postgres/inst/bin:"$PATH"
             sh configure
-            make PROFILE="-Wall -Wmissing-prototypes -Werror" -j4 all install
+            make PROFILE="-Wall -Wmissing-prototypes -Werror=maybe-uninitialized -Werror" -j4 all install
 
       - name: Run BDR core tests
         run: |

--- a/bdr_locks.c
+++ b/bdr_locks.c
@@ -962,7 +962,7 @@ void
 bdr_acquire_ddl_lock(BDRLockType lock_type)
 {
 	StringInfoData s;
-	TimestampTz endtime PG_USED_FOR_ASSERTS_ONLY;
+	TimestampTz endtime PG_USED_FOR_ASSERTS_ONLY = 0;
 
 	Assert(IsTransactionState());
 	/* Not called from within a BDR worker */


### PR DESCRIPTION

bdr_locks.c:1159:39: error: ‘endtime’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1159 |                         cur_timeout = TimestampDifferenceMilliseconds(now, endtime);
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Fixing and while at it changing the compiler options to CI build.
