### PR TITLE
Fix a deadlock between per-db worker and backend process

### DIFF
--- a/include/bdr.h
+++ b/include/bdr.h
@@ -673,7 +673,9 @@ extern void bdr_nodes_set_local_attrs(BdrNodeStatus status, BdrNodeStatus oldsta
 extern List *bdr_read_connection_configs(void);
 
 /* return a node name or (none) if unknown for given nodeid */
-extern const char *bdr_nodeid_name(const BDRNodeId * const node, bool missing_ok);
+extern const char *bdr_nodeid_name(const BDRNodeId * const node,
+								   bool missing_ok,
+								   bool only_cache_lookup);
 
 extern void
 			stringify_my_node_identity(char *sysid_str, Size sysid_str_size,
@@ -695,7 +697,7 @@ extern void bdr_nodecache_invalidate(void);
 extern bool bdr_local_node_read_only(void);
 extern char bdr_local_node_status(void);
 extern int32 bdr_local_node_seq_id(void);
-extern const char *bdr_local_node_name(void);
+extern const char *bdr_local_node_name(bool only_cache_lookup);
 
 extern void bdr_set_node_read_only_guts(char *node_name, bool read_only, bool force);
 extern void bdr_setup_my_cached_node_names(void);

--- a/include/bdr_locks.h
+++ b/include/bdr_locks.h
@@ -40,4 +40,6 @@ extern BDRLockType bdr_lock_name_to_type(const char *lock_type);
 
 extern void bdr_locks_node_detached(BDRNodeId * node);
 
+extern bool IsBDRLocksShmemLockHeldByMe(void);
+
 #endif

--- a/src/bdr_ddlrep.c
+++ b/src/bdr_ddlrep.c
@@ -59,7 +59,7 @@ bdr_queue_ddl_command(const char *command_tag, const char *command, const char *
 
 	elog(DEBUG2, "node %s enqueuing DDL command \"%s\" "
 		 "with search_path \"%s\"",
-		 bdr_local_node_name(), command,
+		 bdr_local_node_name(false), command,
 		 search_path == NULL ? "" : search_path);
 
 	if (search_path == NULL)

--- a/src/bdr_locks.c
+++ b/src/bdr_locks.c
@@ -2566,3 +2566,13 @@ bdr_get_global_locks_info(PG_FUNCTION_ARGS)
 	returnTuple = heap_form_tuple(tupleDesc, values, isnull);
 	PG_RETURN_DATUM(HeapTupleGetDatum(returnTuple));
 }
+
+/*
+ * A simple wrapper to check if calling process is currently holding bdr_locks
+ * shared memory lock.
+ */
+bool
+IsBDRLocksShmemLockHeldByMe(void)
+{
+	return bdr_locks_ctl == NULL ? false : LWLockHeldByMe(bdr_locks_ctl->lock);
+}

--- a/src/bdr_perdb.c
+++ b/src/bdr_perdb.c
@@ -478,7 +478,8 @@ bdr_maintain_db_workers(void)
 								NameStr(slot_name_dropped)) == 0)
 				{
 					elog(DEBUG1, "need to drop slot %s of detached node %s",
-						 NameStr(s->data.name), bdr_nodeid_name(node, true));
+						 NameStr(s->data.name),
+						 bdr_nodeid_name(node, true, false));
 					drop = lappend(drop, pstrdup(NameStr(s->data.name)));
 				}
 			}
@@ -765,8 +766,8 @@ bdr_maintain_db_workers(void)
 		/* Set the display name in 'ps' etc */
 		snprintf(bgw.bgw_name, BGW_MAXLEN,
 				 "bdr apply worker for %s to %s",
-				 bdr_nodeid_name(&target, true),
-				 bdr_nodeid_name(&myid, true));
+				 bdr_nodeid_name(&target, true, false),
+				 bdr_nodeid_name(&myid, true, false));
 
 		/* Allocate a new shmem slot for this apply worker */
 		worker = bdr_worker_shmem_alloc(BDR_WORKER_APPLY, &slot);

--- a/test/t/utils/nodemanagement.pm
+++ b/test/t/utils/nodemanagement.pm
@@ -171,7 +171,11 @@ sub initandstart_node {
 sub bdr_update_postgresql_conf {
     my ($node) = shift;
 
-    my $ddl_lock_acquire_timeout =
+    # Set timeouts for lock acquire to avoid indefinite wait loops in tests.
+    # For example, it was noticed in CI tests that LOCK TABLE on bdr.bdr_nodes
+    # in bdr.bdr_detach_nodes can sporadically cause indefinite wait loop in
+    # 042_concurrency_physical.pl.
+    my $lock_acquire_timeout =
         $PostgreSQL::Test::Utils::timeout_default .'s';
 
     # Setting bdr.trace_replay=on here can be a big help, so added for
@@ -191,7 +195,8 @@ sub bdr_update_postgresql_conf {
             log_line_prefix = '%m %p %d [%a] %c:%l (%v:%t) '
 			bdr.skip_ddl_replication = false
             bdr.max_nodes = 20
-            bdr.bdr_ddl_lock_acquire_timeout = $ddl_lock_acquire_timeout
+            bdr.bdr_ddl_lock_acquire_timeout = $lock_acquire_timeout
+            lock_timeout = $lock_acquire_timeout
     ));
 }
 


### PR DESCRIPTION
A deadlock can occur when look up for a node name leads to reading from bdr.bdr_nodes table (node cache miss) while holding bdr_locks shared memory lock. The deadlock was observed in one of the TAP test 042_concurrency_physical.pl, and it looked like the following:

1. A per-db worker while holding bdr_locks shared memory lock from bdr_locks_node_detached() tried to read a node name (via BDR_NODEID_FORMAT_WITHNAME_ARGS) to print in log message. This node name read from node cache lead to reading from bdr.bdr_nodes table in bdr_nodes_get_local_info() which requires an exclusive lock on the table.

2. A backend process related to the connection opened by bdr_nodes_set_remote_status_ready() was trying to commit a transaction while holding the exclusive lock on bdr.bdr_nodes table. This led to bdr_lock_holder_xact_callback() requiring bdr_locks shared memory lock.

In short, the per-db worker held bdr_locks shared memory lock, and waiting to acquire exclusive lock on bdr.bdr_nodes table. The backend process held exclusive lock on bdr.bdr_nodes table, and waiting to acquire bdr_locks shared memory lock. This led to deadlock.

A simple fix here is to disallow reading node name from bdr.bdr_nodes table when node cache miss happens while holding bdr_locks shared memory lock. In this case, "(unknown)" is returned as node name. This fix is simple because the node name read functions bdr_get_my_cached_node_name() and bdr_get_my_cached_remote_name() are mostly called to print node names in log messages. What may happen is that the log messages will have a valid node id with node name as "(unknown)", the valid node id will help distiguish the log messages for every node.

When deadlock occurs, the TAP test 042_concurrency_physical.pl gets into in indefinite wait loop. Because, the TAP test runs bdr.bdr_detach_nodes() which again needs exclusive lock on bdr.bdr_nodes table via LOCK TABLE command. But, the deadlock never lets bdr.bdr_detach_nodes() get the lock. To avoid indefinite wait loop, set postgres lock_timeout GUC for all of the TAP tests. With this, the LOCK TABLE command throws timeout error.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
