### PR TITLE
Add pgindent check to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           src/compat/16/pg_dump/*
           EOF
           src/tools/pgindent/pgindent --indent=$GITHUB_WORKSPACE/postgres/src/tools/pg_bsd_indent/pg_bsd_indent --excludes=pgindent.ignore --show-diff $GITHUB_WORKSPACE/bdr > pgindent.diffs
-          test -s pgindent.diffs && cat pgindent.diffs && exit 1
+          test -s pgindent.diffs && cat pgindent.diffs && exit 1 || exit 0
 
       - name: Build BDR
         run: |


### PR DESCRIPTION
This commit runs pgindent on BDR code with PG16 branch where postgres maintains pg_bsd_indent tool in code. If any pgindent diffs are found, the CI run on PG16 fails, and the onus is on developers to fix the indentation in their code. This saves others time in running pgindent and keeps the coding standards high on par with postgres. This is inspired by similar work postgres did - where a separate buildfarm member was introduced to complain if pgindent check fails.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
