### PR TITLE
Fix compilation issue when --with-lz2 or.and --with-zstd is used

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -146,6 +146,8 @@ BDR_DUMP_OBJS = $(BDR_DUMP_DIR)/pg_dump.o \
 	$(BDR_DUMP_DIR)/dumputils.o \
 	$(BDR_DUMP_DIR)/compress_io.o
 
+BDR_DUMP_LIBS = $(shell $(PG_CONFIG) --libs) -lpgfeutils
+
 ifneq ($(wildcard $(BDR_DUMP_DIR)/compress_lz4.c),)
 	BDR_DUMP_OBJS += $(BDR_DUMP_DIR)/compress_lz4.o
 endif
@@ -169,7 +171,7 @@ endif
 BDR_DUMP_OBJS += $(BDR_DUMP_DIR)/string_utils.o
 
 bdr_dump: $(BDR_DUMP_OBJS)
-	$(CC) $(CFLAGS) $(BDR_DUMP_OBJS) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) -lz -lpgfeutils -o $@$(X)
+	$(CC) $(CFLAGS) $(BDR_DUMP_OBJS) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(BDR_DUMP_LIBS) -o $@$(X)
 
 bdr_init_copy: src/bdr_init_copy.o src/bdr_common.o
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(libpq_pgport) -o $@$(X)


### PR DESCRIPTION
Fix compilation for bdr_dump when using LZ4 or/and ZSTD compression
Use PG_CONFIG --libs to get the base LIBs and add other required libs

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
