### PR TITLE
Fix flakiness in TAP tests

### DIFF
--- a/test/t/120_bdr_remove_bdr_from_node.pl
+++ b/test/t/120_bdr_remove_bdr_from_node.pl
@@ -53,6 +53,16 @@ sub bdr_remove_and_localize_seqs {
     my $node      = shift;
     my $is_detached = shift;
     if ( defined $is_detached && $is_detached ) {
+        # Ensure detached node knows it is actually detached i.e. its
+        # node_status in bdr.bdr_nodes table is updated as 'k'. Otherwise,
+        # bdr.bdr_remove() fails with exception:
+        # 'this BDR node might still be active, not removing'.
+        my $node_name = $node->name();
+	    my $query =
+	        qq[SELECT node_status = 'k' FROM bdr.bdr_nodes WHERE node_name = '$node_name';];
+	    $node->poll_query_until($bdr_test_dbname, $query)
+	        or croak ("timed out waiting for detached node to know it's detached");
+
         $node->safe_psql( $bdr_test_dbname, "select bdr.bdr_remove()" );
         is( $node->safe_psql( $bdr_test_dbname, "select bdr.bdr_is_active_in_db()"),
             'f',

--- a/test/t/utils/nodemanagement.pm
+++ b/test/t/utils/nodemanagement.pm
@@ -33,7 +33,6 @@ use vars qw(@ISA @EXPORT @EXPORT_OK);
     create_bdr_group
     initandstart_physicaljoin_node
     check_join_status
-    check_detach_status
     bdr_detach_nodes
     check_detach_status
     stop_nodes


### PR DESCRIPTION
Two of the TAP tests in 045_unregister_workers_after_detach.pl and 120_bdr_remove_bdr_from_node.pl are failing sporadically as following:

not ok 19 - unregistering apply worker on node_0 is detected ERROR:  this BDR node might still be active, not removing

These failures seem to be due to the function
check_detach_status() in TAP tests not checking the local node status to be 'k'/killed. IOW, check_detach_status() doesn't check if node_status of a detached node in bdr.bdr_nodes table is 'k'. While this works for other callsites of check_detach_status(), the two sporadically failing TAP tests need to the detached node to know it is actually detached. In
045_unregister_workers_after_detach.pl, the apply worker unregisters only upon detecting the node_status is 'k'. In, 120_bdr_remove_bdr_from_node.pl, the non-force bdr.bdr_remove(), raises exception when the node_status is not 'k'.

Fix provided in this commit ensures the node_status on detached node is 'k' before the check for unregistering apply worker and non-force bdr.bdr_remove().

While here, two other improvements are done:
- Removed a duplicate export of check_detach_status() in t/utils/nodemanagement.pm

- Used 2 node BDR group in 045_unregister_workers_after_detach.pl, the 3rd node wasn't actually used for any purpose. This saves an unnecessary node bringup time.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
