### PR TITLE
Replace croak() with die() for poll_query_until failures

### DIFF
--- a/test/t/045_unregister_workers_after_detach.pl
+++ b/test/t/045_unregister_workers_after_detach.pl
@@ -32,7 +32,7 @@ my $node_0_name = $node_0->name();
 my $query =
 	qq[SELECT node_status = 'k' FROM bdr.bdr_nodes WHERE node_name = '$node_0_name';];
 $node_0->poll_query_until($bdr_test_dbname, $query)
-	or croak ("timed out waiting for detached node to know it's detached");
+	or die "timed out waiting for detached node to know it's detached";
 
 # Detached node must unregister apply worker
 my $result = wait_for_worker_to_unregister($node_0,

--- a/test/t/120_bdr_remove_bdr_from_node.pl
+++ b/test/t/120_bdr_remove_bdr_from_node.pl
@@ -61,7 +61,7 @@ sub bdr_remove_and_localize_seqs {
 	    my $query =
 	        qq[SELECT node_status = 'k' FROM bdr.bdr_nodes WHERE node_name = '$node_name';];
 	    $node->poll_query_until($bdr_test_dbname, $query)
-	        or croak ("timed out waiting for detached node to know it's detached");
+	        or die "timed out waiting for detached node to know it's detached";
 
         $node->safe_psql( $bdr_test_dbname, "select bdr.bdr_remove()" );
         is( $node->safe_psql( $bdr_test_dbname, "select bdr.bdr_is_active_in_db()"),


### PR DESCRIPTION
Commit 98700ef6 added poll_query_until failure messages to report via perl's croak() function. A CI member isn't happy with it and complains [1]. Use die() instead of croak() similar to postgres TAP tests.

[1]
poll_query_until timed out executing this query:
SELECT node_status = 'k' FROM bdr.bdr_nodes WHERE node_name = 'node_0'; expecting this output:
t
last actual query output:
f
with stderr:

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
