### PR TITLE
Add TAP test to demo pg_dump and pg_restore of a BDR node

### DIFF
--- a/bdr--2.1.0.sql
+++ b/bdr--2.1.0.sql
@@ -529,7 +529,7 @@ COMMENT ON COLUMN bdr_connections.conn_dsn IS 'A libpq-style connection string s
 COMMENT ON COLUMN bdr_connections.conn_apply_delay IS 'If set, milliseconds to wait before applying each transaction from the remote node. Mainly for debugging. If null, the global default applies.';
 COMMENT ON COLUMN bdr_connections.conn_replication_sets IS 'Replication sets this connection should participate in, if non-default';
 
-SELECT pg_catalog.pg_extension_config_dump('bdr_connections', '');
+SELECT pg_catalog.pg_extension_config_dump('bdr_connections', 'WHERE false');
 
 CREATE FUNCTION bdr_connections_changed()
 RETURNS void

--- a/test/t/056_verify_dump_and_restore_of_bdr_node.pl
+++ b/test/t/056_verify_dump_and_restore_of_bdr_node.pl
@@ -1,0 +1,154 @@
+#!/usr/bin/env perl
+#
+# Test co-existence of multiple BDR groups on a single postgres cluster
+use strict;
+use warnings;
+use lib 'test/t/';
+use Cwd;
+use Config;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use IPC::Run;
+use Test::More;
+use utils::nodemanagement;
+
+# Create an upstream node and bring up bdr
+my $alpha = 'alpha';
+my $node_0 = create_bdr_group_with_db('node_0', $alpha);
+
+# Join BDR group 1 on postgres cluster 2 with database alpha
+my $node_1 = join_bdr_group_with_db('node_1', $node_0, $alpha);
+
+create_and_check_data($node_0, $node_1, $alpha);
+
+my $pg_version = $node_1->safe_psql($alpha,
+    q[select setting::int/10000 from pg_settings where name = 'server_version_num';]);
+
+my $backupdir = $node_0->backup_dir;
+my $plain = "$backupdir/plain.sql";
+
+# Take pg_dump of a BDR node.
+#
+# BDR uses security labels, so we will have to generate dump without security
+# labels, otherwise restored database will have command attaching BDR security
+# label.
+#
+# We'll need to exclude BDR schema from dumping to not get BDR catalogs.
+#
+# We'll need to specify only the needed extensions so that BDR extension can be
+# excluded from dump. Otherwise, BDR extension needs to be dropped immediately
+# after restore. pg_dump option to selectively dump extensions (--extension) is
+# introduced in PG 14, prior to that one has to delete create extension bdr
+# statement from the dump manually.
+if ($pg_version >= 14)
+{
+    $node_0->command_ok(
+        [
+            'pg_dump', '--file', $plain, '--no-security-labels',
+            '--exclude-schema', 'bdr', '--create',
+            '--dbname', $alpha,
+            '--extension', 'plpgsql'
+        ],
+        'pg_dump of a BDR node');
+}
+else
+{
+    $node_0->command_ok(
+        [
+            'pg_dump', '--file', $plain, '--no-security-labels',
+            '--exclude-schema', 'bdr', '--create',
+            '--dbname', $alpha
+        ],
+        'pg_dump of a BDR node');
+
+    # Delete all lines that contain "bdr"
+    system("sed -i.bak '/bdr/d' $plain");
+}
+
+my $node_2 = PostgreSQL::Test::Cluster->new('node_2');
+$node_2->init;
+$node_2->start;
+
+$node_2->command_ok(['psql', '-f', $plain],
+	'pg_restore from a pg_dump of BDR node succeeds');
+
+# BDR extension mustn't exist on restored node
+my $res = $node_2->safe_psql($alpha,
+    qq[SELECT COUNT(*) = 0 FROM pg_extension WHERE extname = 'bdr';]);
+is($res, 't', "BDR extension doesn't exist on pg_restore-d node " . $node_2->name() ."");
+
+$res = $node_2->safe_psql($alpha, qq[SELECT COUNT(*) FROM fruits;]);
+is($res, '2', "pg_restore-d node " . $node_2->name() . "has all the data");
+
+done_testing();
+
+sub create_bdr_group_with_db {
+    my ($node_name, $db) = @_;
+
+    my $node = PostgreSQL::Test::Cluster->new($node_name);
+    initandstart_node($node, $db);
+
+    my $port = $node->port;
+    my $host = $node->host;
+    my $node_connstr = "port=$port host=$host dbname=$db";
+
+    $node->safe_psql($db, qq{
+        SELECT bdr.bdr_create_group(
+            local_node_name := '$node_name',
+            node_external_dsn := '$node_connstr');});
+    $node->safe_psql($db, qq[
+        SELECT bdr.bdr_wait_for_node_ready($PostgreSQL::Test::Utils::timeout_default)]);
+    $node->safe_psql($db, 'SELECT bdr.bdr_is_active_in_db()' ) eq 't'
+    or BAIL_OUT('!bdr.bdr_is_active_in_db() after bdr_create_group');
+
+    return $node;
+}
+
+sub join_bdr_group_with_db {
+    my ($node_name, $upstream_node, $db) = @_;
+
+    my $node = PostgreSQL::Test::Cluster->new($node_name);
+    initandstart_node($node, $db);
+
+    my $port = $node->port;
+    my $host = $node->host;
+    my $node_connstr = "port=$port host=$host dbname=$db";
+
+    $port = $upstream_node->port;
+    $host = $upstream_node->host;
+    my $upstream_node_connstr = "port=$port host=$host dbname=$db";
+
+    $node->safe_psql($db, qq{
+        SELECT bdr.bdr_join_group(
+            local_node_name := '$node_name',
+            node_external_dsn := '$node_connstr',
+            join_using_dsn := '$upstream_node_connstr');});
+    $node->safe_psql($db, qq[
+        SELECT bdr.bdr_wait_for_node_ready($PostgreSQL::Test::Utils::timeout_default)]);
+    $node->safe_psql($db, 'SELECT bdr.bdr_is_active_in_db()' ) eq 't'
+    or BAIL_OUT('!bdr.bdr_is_active_in_db() after bdr_join_group');
+
+    return $node;
+}
+
+sub create_and_check_data {
+    my ($node1, $node2, $db) = @_;
+
+    $node1->safe_psql($db,
+        q[CREATE TABLE fruits(id integer, name varchar);]);
+    $node1->safe_psql($db,
+        q[INSERT INTO fruits VALUES (1, 'Mango');]);
+    wait_for_apply($node1, $node2);
+
+    $node2->safe_psql($db,
+        q[INSERT INTO fruits VALUES (2, 'Apple');]);
+    wait_for_apply($node2, $node1);
+
+    my $query = qq[SELECT COUNT(*) FROM fruits;];
+    my $expected = 2;
+    my $res1 = $node1->safe_psql($db, $query);
+    my $res2 = $node2->safe_psql($db, $query);
+
+    is($res1, $expected, "BDR node " . $node1->name() . "has all the data");
+    is($res2, $expected, "BDR node " . $node2->name() . "has all the data");
+}

--- a/test/t/utils/nodemanagement.pm
+++ b/test/t/utils/nodemanagement.pm
@@ -156,13 +156,13 @@ sub initandstart_bdr_group {
 # Init and start node with BDR, create the test DB and install the BDR
 # extension.
 sub initandstart_node {
-    my ($node, $bdr_test_dbname, %kwopts) = @_;
+    my ($node, $db, %kwopts) = @_;
 
     $node->init( hba_permit_replication => 1, allows_streaming => 1,
 				 %{$kwopts{extra_init_opts}//{}} );
     bdr_update_postgresql_conf( $node );
     $node->start;
-    _create_db_and_exts( $node, $bdr_test_dbname );
+    _create_db_and_exts( $node, $db );
 
 }
 
@@ -200,10 +200,12 @@ sub bdr_update_postgresql_conf {
 }
 
 sub _create_db_and_exts {
-    my $node = shift;
+    my ($node, $db) = @_;
 
-    $node->safe_psql( 'postgres', qq{CREATE DATABASE $bdr_test_dbname;} );
-    $node->safe_psql( $bdr_test_dbname,    q{CREATE EXTENSION bdr;} );
+    $db = $bdr_test_dbname if !defined($db);
+
+    $node->safe_psql( 'postgres', qq{CREATE DATABASE $db;} );
+    $node->safe_psql( $db,    q{CREATE EXTENSION bdr;} );
 
 }
 sub initandstart_join_node {


### PR DESCRIPTION
This commit adds a TAP test to demonstrate taking pg_dump from a BDR node without getting BDR machinery in the dump.

This commit also adds bdr.bdr_connections to pg_dump exclusion list like its friend bdr.bdr_nodes. Otherwise, pg_dump dumps bdr.bdr_connections table contents unnecessarily. BDR syncs and maintain both bdr.bdr_nodes and bdr.bdr_connections global to a BDR group and the logical node join skips getting both of them from remote node.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
