### PR TITLE
Fail fast if wal_level isn't logical

### DIFF
--- a/src/bdr.c
+++ b/src/bdr.c
@@ -977,12 +977,17 @@ _PG_init(void)
 		if (!process_shared_preload_libraries_in_progress)
 			ereport(ERROR,
 					(errcode(ERRCODE_CONFIG_FILE_ERROR),
-					 errmsg("bdr can only be loaded via shared_preload_libraries")));
+					 errmsg("bdr must be loaded via shared_preload_libraries")));
 
 		if (!track_commit_timestamp)
 			ereport(ERROR,
 					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-					 errmsg("bdr requires \"track_commit_timestamp\" to be enabled")));
+					 errmsg("bdr requires track_commit_timestamp to be enabled")));
+
+		if (wal_level < WAL_LEVEL_LOGICAL)
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("bdr requires wal_level >= logical")));
 	}
 
 	/* XXX: make it changeable at SIGHUP? */


### PR DESCRIPTION
BDR requires wal_level = logical, if not it fails at a later stage while starting up BDR workers. This is hard to notice because one has to look at server logs. Instead, let BDR fail fast when shared library is first loaded. This is similar to check that BDR has for track_commit_timestamp.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
