### PR TITLE
Ensure skip_dll_replication has same value on all nodes

### DIFF
--- a/doc/bdr-configuration-variables.md
+++ b/doc/bdr-configuration-variables.md
@@ -144,8 +144,12 @@ server restart to take effect.
 
     Only affects BDR. Skips replication and apply of DDL changes.
     This is set to on by default so that a BDR node bevahes as a non BDR one by
-    default.  This option can be changed globally or enabled locally
-    (at the session level) but only by superusers.
+    default. A new node fails to join a BDR group if it has a different value
+    for this parameter when compared with its upstream node. An existing node
+    can't start BDR workers if the parameter value doesn't match with its
+    upstream node. Hence, users must ensure all BDR members have the same value
+    for the parameter at any point of time. This option can be changed globally
+    or enabled locally (at the session level) but only by superusers.
 
     ::: WARNING
       **Warning**

--- a/include/bdr.h
+++ b/include/bdr.h
@@ -767,6 +767,7 @@ typedef struct remote_node_info
 	char	   *dbname;
 	int64		dbsize;			/* database size in bytes */
 	int			max_nodes;
+	bool		skip_ddl_replication;
 	int			cur_nodes;
 
 	/* collation related info */

--- a/src/bdr.c
+++ b/src/bdr.c
@@ -1033,7 +1033,8 @@ _PG_init(void)
 
 	DefineCustomBoolVariable("bdr.skip_ddl_replication",
 							 "Internal. Set during local restore during init_replica only",
-							 NULL,
+							 "This parameter must be set to the same value on all BDR members, otherwise "
+							 "a new node can't join BDR group or an existing node can't start BDR workers.",
 							 &bdr_skip_ddl_replication,
 							 true,
 							 PGC_SUSET,

--- a/src/bdr_perdb.c
+++ b/src/bdr_perdb.c
@@ -942,8 +942,8 @@ bdr_perdb_worker_main(Datum main_arg)
 
 		/*
 		 * Check whether the local node and remote node have same
-		 * bdr.max_nodes GUC value, if they don't, let's not proceed further
-		 * unless the same value is set to same on both the nodes.
+		 * bdr.max_nodes and bdr.skip_ddl_replication GUC values, if they
+		 * don't, let's not proceed further.
 		 */
 		if (local_node->init_from_dsn != NULL)
 		{
@@ -966,6 +966,15 @@ bdr_perdb_worker_main(Datum main_arg)
 									bdr_max_nodes,
 									BDR_LOCALID_FORMAT_ARGS,
 									ri.max_nodes),
+							 errhint("The parameter must be set to the same value on all BDR members.")));
+
+				if (prev_bdr_skip_ddl_replication != ri.skip_ddl_replication)
+					ereport(ERROR,
+							(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+							 errmsg("bdr.skip_ddl_replication parameter value (%s) on local node " BDR_NODEID_FORMAT " doesn't match with remote node (%s)",
+									prev_bdr_skip_ddl_replication ? "true" : "false",
+									BDR_LOCALID_FORMAT_ARGS,
+									ri.skip_ddl_replication ? "true" : "false"),
 							 errhint("The parameter must be set to the same value on all BDR members.")));
 
 				free_remote_node_info(&ri);

--- a/src/bdr_remotecalls.c
+++ b/src/bdr_remotecalls.c
@@ -265,6 +265,7 @@ bdr_get_remote_nodeinfo_internal(PGconn *conn, struct remote_node_info *ri)
 				 "current_database()::text AS dbname, "
 				 "pg_database_size(current_database()) AS dbsize, "
 				 "current_setting('bdr.max_nodes') AS max_nodes, "
+				 "current_setting('bdr.skip_ddl_replication') AS skip_ddl_replication, "
 				 "count(1) FROM bdr.bdr_nodes WHERE node_status NOT IN (bdr.bdr_node_status_to_char('BDR_NODE_STATUS_KILLED'));");
 
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)
@@ -272,7 +273,7 @@ bdr_get_remote_nodeinfo_internal(PGconn *conn, struct remote_node_info *ri)
 				(errmsg("unable to get BDR information from remote node"),
 				 errdetail("Querying remote failed with: %s", PQerrorMessage(conn))));
 
-	Assert(PQnfields(res) == 10);
+	Assert(PQnfields(res) == 11);
 	Assert(PQntuples(res) == 1);
 	remote_bdr_version_str = PQgetvalue(res, 0, 0);
 	ri->version = pstrdup(remote_bdr_version_str);
@@ -287,8 +288,10 @@ bdr_get_remote_nodeinfo_internal(PGconn *conn, struct remote_node_info *ri)
 							   DirectFunctionCall1(int8in, CStringGetDatum(PQgetvalue(res, 0, 7))));
 	ri->max_nodes = DatumGetInt32(
 								  DirectFunctionCall1(int4in, CStringGetDatum(PQgetvalue(res, 0, 8))));
+	ri->skip_ddl_replication = DatumGetBool(
+											DirectFunctionCall1(boolin, CStringGetDatum(PQgetvalue(res, 0, 9))));
 	ri->cur_nodes = DatumGetInt32(
-								  DirectFunctionCall1(int4in, CStringGetDatum(PQgetvalue(res, 0, 9))));
+								  DirectFunctionCall1(int4in, CStringGetDatum(PQgetvalue(res, 0, 10))));
 	PQclear(res);
 
 	/*
@@ -381,8 +384,8 @@ Datum
 bdr_get_remote_nodeinfo(PG_FUNCTION_ARGS)
 {
 	const char *remote_node_dsn = text_to_cstring(PG_GETARG_TEXT_P(0));
-	Datum		values[16];
-	bool		isnull[16];
+	Datum		values[17];
+	bool		isnull[17];
 	TupleDesc	tupleDesc;
 	HeapTuple	returnTuple;
 	PGconn	   *conn;
@@ -430,17 +433,18 @@ bdr_get_remote_nodeinfo(PG_FUNCTION_ARGS)
 		values[10] = CStringGetTextDatum(ri.dbname);
 		values[11] = Int64GetDatum(ri.dbsize);
 		values[12] = Int32GetDatum(ri.max_nodes);
-		values[13] = Int32GetDatum(ri.cur_nodes);
+		values[13] = BoolGetDatum(ri.skip_ddl_replication);
+		values[14] = Int32GetDatum(ri.cur_nodes);
 
 		if (ri.datcollate == NULL)
-			isnull[14] = true;
-		else
-			values[14] = CStringGetTextDatum(ri.datcollate);
-
-		if (ri.datctype == NULL)
 			isnull[15] = true;
 		else
-			values[15] = CStringGetTextDatum(ri.datctype);
+			values[15] = CStringGetTextDatum(ri.datcollate);
+
+		if (ri.datctype == NULL)
+			isnull[16] = true;
+		else
+			values[16] = CStringGetTextDatum(ri.datctype);
 
 		returnTuple = heap_form_tuple(tupleDesc, values, isnull);
 


### PR DESCRIPTION
A new node fails to join a BDR group if it has a different value for this parameter when compared with its upstream node. An existing node can't start BDR workers if the parameter value doesn't match with its upstream node. Hence, users must ensure all BDR members have the same value for the parameter at any point of time.
