### PR TITLE
Add function to update BDR machinery when endpoint changes

### DIFF
--- a/bdr--2.1.0.sql
+++ b/bdr--2.1.0.sql
@@ -1991,7 +1991,7 @@ DECLARE
   r record;
   updated_rows int; -- a variable to store the row count
 BEGIN
-  -- Only one tx can be update node connection info
+  -- Only one tx can update node connection info
   LOCK TABLE bdr.bdr_nodes IN EXCLUSIVE MODE;
   LOCK TABLE bdr.bdr_connections IN EXCLUSIVE MODE;
 
@@ -2011,7 +2011,7 @@ BEGIN
 
   GET DIAGNOSTICS updated_rows = ROW_COUNT;
   IF updated_rows = 0 THEN
-    RAISE EXCEPTION 'node_init_from_dsn is not updated';
+    RAISE EXCEPTION 'could not find any row in bdr.bdr_nodes to update node_init_from_dsn';
   END IF;
 
   -- Update node DSN for passed-in node.
@@ -2021,7 +2021,7 @@ BEGIN
 
   GET DIAGNOSTICS updated_rows = ROW_COUNT;
   IF updated_rows = 0 THEN
-    RAISE EXCEPTION 'node_local_dsn is not updated';
+    RAISE EXCEPTION 'could not find any row in bdr.bdr_nodes to update node_local_dsn';
   END IF;
 
   -- Update node DSN for passed-in node in bdr.bdr_connections.
@@ -2033,7 +2033,7 @@ BEGIN
 
   GET DIAGNOSTICS updated_rows = ROW_COUNT;
   IF updated_rows = 0 THEN
-    RAISE EXCEPTION 'conn_dsn is not updated';
+    RAISE EXCEPTION 'could not find any row in bdr.bdr_connections to update conn_dsn';
   END IF;
 END;
 $body$;

--- a/src/bdr.c
+++ b/src/bdr.c
@@ -1929,7 +1929,7 @@ bdr_conninfo_cmp(PG_FUNCTION_ARGS)
 
 		for (opt2 = opts2; opt2->keyword != NULL; ++opt2)
 		{
-			if (strcmp(opt1->keyword, opt2->keyword) == 0)
+			if (pg_strcasecmp(opt1->keyword, opt2->keyword) == 0)
 			{
 				if (opt1->val == NULL && opt2->val == NULL)
 				{
@@ -1941,7 +1941,7 @@ bdr_conninfo_cmp(PG_FUNCTION_ARGS)
 					(opt1->val != NULL && opt2->val == NULL))
 					break;
 
-				if (strcmp(opt1->val, opt2->val) == 0)
+				if (pg_strcasecmp(opt1->val, opt2->val) == 0)
 				{
 					found = true;
 					break;

--- a/test/t/054_failover_of_bdr_node_in_stream_repl.pl
+++ b/test/t/054_failover_of_bdr_node_in_stream_repl.pl
@@ -171,21 +171,21 @@ is($node_1_res, $expected, "BDR node node_1 has all the DDL data after new prima
 $pgport = $node_1->port;
 $pghost = $node_1->host;
 
-# Connection strings are equivalent with entries are in different order
+# Connection strings are equivalent with entries in different order
 my $connstr1 = "port=$pgport host=$pghost dbname=$bdr_test_dbname";
 my $connstr2 = "dbname=$bdr_test_dbname host=$pghost port=$pgport";
 $query = qq[SELECT bdr.bdr_conninfo_cmp('$connstr1', '$connstr2');];
 $node_1_res = $node_1->safe_psql($bdr_test_dbname, $query);
 is($node_1_res, 't', "connection strings are equivalent with entries in different order");
 
-# Connection strings are equivalent with entries are in same order
+# Connection strings are equivalent with entries in same order
 $connstr1 = "port=$pgport host=$pghost dbname=$bdr_test_dbname";
 $connstr2 = "port=$pgport host=$pghost dbname=$bdr_test_dbname";
 $query = qq[SELECT bdr.bdr_conninfo_cmp('$connstr1', '$connstr2');];
 $node_1_res = $node_1->safe_psql($bdr_test_dbname, $query);
 is($node_1_res, 't', "connection strings are equivalent with entries in same order");
 
-# Connection strings are equivalent with entries are in same order
+# Connection strings are different for different servers
 $connstr1 = $node_0_standby_connstr;
 $connstr2 = $node_1_connstr;
 $query = qq[SELECT bdr.bdr_conninfo_cmp('$connstr1', '$connstr2');];


### PR DESCRIPTION
This commit adds a function to help with updating BDR internal tables whenever any of connection string entries changes - endpoint/host name or port numbers etc. This function takes node name and new connection string as input, and updates BDR internal tables that uses the node connection string. After updating new connection string with this function, it is required to restart all the BDR nodes for the new changes to take effect.

This commit also adds a utility function to compare two given postgres connection strings regardless of the order of the connection string entries. This is needed to compare connection entries in BDR internal tables while updating with new connection string.

Test cases are added in 054_failover_of_bdr_node_in_stream_repl.pl for the newly added functions.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
