### PR TITLE
Add code coverage GitHub CI action

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -1,0 +1,99 @@
+name: BDR code coverage CI
+on:
+  workflow_dispatch:
+jobs:
+  test:
+    defaults:
+      run:
+        shell: sh
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        version: [REL_16_STABLE, REL_15_STABLE, REL_11_STABLE]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout BDR
+        uses: actions/checkout@v3
+        with:
+          path: bdr
+
+      - name: Checkout Postgres
+        run: |
+          sudo apt-get -y -q install libipc-run-perl lcov
+          git clone --branch ${{ matrix.version }} https://github.com/postgres/postgres.git
+
+      - name: Build Postgres
+        run: |
+          cd postgres
+          sh configure --prefix=$PWD/inst/ --enable-debug --enable-cassert --enable-tap-tests --enable-coverage CFLAGS="-ggdb3 -O0"
+          make -j4 install
+
+          # Install extensions required for BDR tests
+          make -C contrib/btree_gist install
+          make -C contrib/cube install
+          make -C contrib/hstore install
+          make -C contrib/pg_trgm install
+
+      - name: Build BDR
+        run: |
+            cd bdr
+            PATH=$GITHUB_WORKSPACE/postgres/inst/bin:"$PATH"
+            sh configure
+            make PROFILE="-Wall -Wmissing-prototypes -Werror=maybe-uninitialized -Werror" -j4 all install
+
+      - name: Run BDR core tests
+        run: |
+          cd bdr
+          make regress_check
+
+      - name: Show BDR core tests diff
+        if: ${{ failure() }}
+        run: |
+          cat bdr/test/regression.diffs
+
+      - name: Run BDR extended tests
+        run: |
+          cd bdr
+          make PROVE_FLAGS="--timer -v" prove_check
+
+      - name: Upload test artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-artifact-${{ matrix.os }}-${{ matrix.version }}
+          path: |
+            bdr/test/regression.diffs
+            bdr/test/tmp_check/log
+          retention-days: 7
+
+      - name: Collect code coverage info
+        if: ${{ always() }}
+        run: |
+          # The steps to run code coverage are referred from
+          # https://www.postgresql.org/message-id/CAB7nPqQkUyN_A88Rw4iAaYax%3Dm4DwNPwoScBVyb3ihmfks8uDg%40mail.gmail.com
+          # and https://www.postgresql.org/docs/current/regress-coverage.html
+          cd bdr
+          make coverage-html abs_top_srcdir=$(pwd)
+          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -i -d . -d ./ -o lcov_base.info
+          /usr/bin/lcov --gcov-tool /usr/bin/gcov -q --no-external -c -d . -d ./ -o lcov_test.info
+          rm -rf coverage
+          /usr/bin/genhtml --legend -o coverage-${{ matrix.version }} --title='BDR on ${{ matrix.version }}' --num-spaces=4  lcov_base.info lcov_test.info
+
+          # Clean up steps. They are here as demonstration for developers
+          # running code coverage indvidually.
+          # rm -rf  coverage coverage-${{ matrix.version }} coverage-html-stamp
+          # rm -f src/*.gcda src/*.gcno src/lcov*.info src/*.gcov src/.*.gcov src/*.gcov.out lcov_base.info lcov_test.info
+
+      - name: Upload code coverage artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-artifact-${{ matrix.os }}-${{ matrix.version }}
+          path: |
+            bdr/coverage-${{ matrix.version }}
+          retention-days: 7

--- a/test/expected/terminate.out
+++ b/test/expected/terminate.out
@@ -102,6 +102,12 @@ SELECT wait_for_nworkers(2);
  
 (1 row)
 
+SELECT pg_sleep(10);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 BEGIN; SET LOCAL bdr.skip_ddl_replication = true; SELECT bdr._bdr_pause_worker_management_private(true); COMMIT;
  _bdr_pause_worker_management_private 
 --------------------------------------
@@ -122,6 +128,12 @@ SELECT n.node_name, bdr.bdr_terminate_workers(node_sysid, node_timeline, node_db
  node_name | bdr_terminate_workers 
 -----------+-----------------------
  node-pg   | t
+(1 row)
+
+SELECT pg_sleep(10);
+ pg_sleep 
+----------
+ 
 (1 row)
 
 -- We must remain with our own walsender

--- a/test/sql/terminate.sql
+++ b/test/sql/terminate.sql
@@ -60,6 +60,8 @@ BEGIN; SET LOCAL bdr.skip_ddl_replication = true; SELECT bdr._bdr_pause_worker_m
 
 SELECT wait_for_nworkers(2);
 
+SELECT pg_sleep(10);
+
 BEGIN; SET LOCAL bdr.skip_ddl_replication = true; SELECT bdr._bdr_pause_worker_management_private(true); COMMIT;
 
 -- We're one instance with two databases so we should have two walsender workers
@@ -69,6 +71,8 @@ SELECT COUNT(*) = 2 AS ok FROM bdr.bdr_get_workers_info() WHERE worker_type = 'w
 SELECT n.node_name, bdr.bdr_terminate_workers(node_sysid, node_timeline, node_dboid, 'walsender')
   FROM bdr.bdr_nodes n
   WHERE (node_sysid, node_timeline, node_dboid) <> bdr.bdr_get_local_nodeid();
+
+SELECT pg_sleep(10);
 
 -- We must remain with our own walsender
 SELECT COUNT(*) = 1 AS ok FROM bdr.bdr_get_workers_info()

--- a/test/t/035_duprows.pl
+++ b/test/t/035_duprows.pl
@@ -78,7 +78,7 @@ $node_a->stop;
 is($node_b->safe_psql($bdr_test_dbname, $query), $expected, 'results node B during restart A');
 $node_a->start;
 # to make sure a is ready for queries again:
-sleep(1);
+sleep(10);
 
 note "taking final DDL lock";
 $node_a->safe_psql($bdr_test_dbname, q[SELECT bdr.bdr_acquire_global_lock('write_lock')]);


### PR DESCRIPTION
This commit adds a GitHub CI action for running code coverage on BDR source code. It produces the code coverage final html files as downloadable artifacts which can be viewed in web browser locally. One can run the code coverage manually by going to GitHub portal's Actions tab and selecting BDR code coverage CI workflow on the left side of the web page, and clicking run workflow on the right side of the web page.

Running BDR tests with --enable-coverage unveiled some test failures that can occur if starting up of BDR workers is slow. To fix those failures, this commit increases the sleep time in tests. However, the failures might have to be fixed in a different way in future, but that's for another day.

=============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
