### PR TITLE
Add workflow_dispatch event trigger to GitHub tests action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths-ignore:
       - 'doc/**'
+  workflow_dispatch:
 jobs:
   test:
     defaults:


### PR DESCRIPTION
This commit adds workflow_dispatch event trigger to GitHub tests action so that the tests can be run on demand.

===============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
