### PR TITLE
Do not expose sensitive information in server log messages

### DIFF
--- a/src/bdr.c
+++ b/src/bdr.c
@@ -285,8 +285,7 @@ bdr_get_remote_dboid(const char *conninfo_db)
 	{
 		ereport(FATAL,
 				(errcode(ERRCODE_CONNECTION_FAILURE),
-				 errmsg("get remote OID: %s", PQerrorMessage(dbConn)),
-				 errdetail("Connection string is '%s'.", conninfo_db)));
+				 errmsg("get remote OID: %s", PQerrorMessage(dbConn))));
 	}
 
 	res = PQexec(dbConn, "SELECT oid FROM pg_database WHERE datname = current_database()");
@@ -365,8 +364,7 @@ bdr_connect(const char *conninfo,
 		ereport(ERROR,
 				(errcode(ERRCODE_CONNECTION_FAILURE),
 				 errmsg("could not connect to the server in replication mode: %s",
-						PQerrorMessage(streamConn)),
-				 errdetail("Connection string is '%s'", conninfo_repl.data)));
+						PQerrorMessage(streamConn))));
 	}
 
 	elog(DEBUG3, "sending replication command: IDENTIFY_SYSTEM");
@@ -412,8 +410,7 @@ bdr_connect(const char *conninfo,
 		ereport(ERROR,
 				(errcode(ERRCODE_CONNECTION_FAILURE),
 				 errmsg("could not connect to the server in non-replication mode: %s",
-						PQerrorMessage(streamConn)),
-				 errdetail("Connection string is '%s'", conninfo_nrepl.data)));
+						PQerrorMessage(streamConn))));
 	}
 
 	cmd = makeStringInfo();

--- a/src/bdr_init_copy.c
+++ b/src/bdr_init_copy.c
@@ -184,7 +184,7 @@ connectdb(char *connstr)
 
 	conn = PQconnectdb(connstr);
 	if (PQstatus(conn) != CONNECTION_OK)
-		die(_("Connection to database failed: %s, connection string was: %s\n"), PQerrorMessage(conn), connstr);
+		die(_("Connection to database failed: %s\n"), PQerrorMessage(conn));
 
 	return conn;
 }

--- a/src/bdr_remotecalls.c
+++ b/src/bdr_remotecalls.c
@@ -81,8 +81,7 @@ bdr_connect_nonrepl(const char *connstring, const char *appnamesuffix)
 	{
 		ereport(FATAL,
 				(errmsg("could not connect to the server in non-replication mode: %s",
-						PQerrorMessage(nonrepl_conn)),
-				 errdetail("dsn was: %s", dsn.data)));
+						PQerrorMessage(nonrepl_conn))));
 	}
 
 	return nonrepl_conn;


### PR DESCRIPTION
Some of the connection failure errors are exposing full connection string in server log messages which exposes sensitive information like endpoint name, passwords etc. This commit removes connection strings from server log messages.

===============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
