### PR TITLE
Reduce number of connection testing functions in pgactive

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -812,9 +812,6 @@ extern void free_remote_node_info(remote_node_info * ri);
 
 extern void pgactive_ensure_ext_installed(PGconn *pgconn);
 
-extern void pgactive_test_remote_connectback_internal(PGconn *conn,
-													  struct remote_node_info *ri, const char *my_dsn);
-
 /*
  * Global to identify the type of pgactive worker the current process is. Primarily
  * useful for assertions and debugging.

--- a/test/expected/identifier.out
+++ b/test/expected/identifier.out
@@ -13,9 +13,10 @@ SELECT current_database() = 'postgres';
  t
 (1 row)
 
--- Test probing for remote node information. Note that local node and remote
--- node having different node identifiers (r.sysid = l.sysid false) as each
--- database gets unique pgactive node identifier.
+-- Test probing for replication connection and get node information of a given
+-- dsn. Note that local node and remote node having different node identifiers
+-- (r.sysid = l.sysid false) as each database gets unique pgactive node
+-- identifier.
 SELECT
 	r.sysid = l.sysid,
 	r.timeline = l.timeline,
@@ -25,42 +26,16 @@ SELECT
 	version_num = pgactive.pgactive_version_num(),
 	min_remote_version_num = pgactive.pgactive_min_remote_version_num(),
 	is_superuser = 't'
-FROM pgactive.pgactive_get_remote_nodeinfo('dbname=regression') r,
+FROM pgactive._pgactive_get_node_info_private('dbname=regression') r,
      pgactive.pgactive_get_local_nodeid() l;
  ?column? | ?column? | ?column? | ?column? | ?column? | ?column? | ?column? | ?column? 
 ----------+----------+----------+----------+----------+----------+----------+----------
  f        | t        | t        | t        | t        | t        | t        | t
 (1 row)
 
--- pgactive.pgactive_get_remote_nodeinfo can also be used to probe the local dsn
--- and make sure it works.
 SELECT
     r.dboid = (SELECT oid FROM pg_database WHERE datname = current_database())
-FROM pgactive.pgactive_get_remote_nodeinfo('dbname='||current_database()) r;
- ?column? 
-----------
- t
-(1 row)
-
--- Test probing for replication connection. Note that local node and remote
--- node having different node identifiers (r.sysid = l.sysid false) as each
--- database gets unique pgactive node identifier.
-SELECT
-	r.sysid = l.sysid,
-	r.timeline = l.timeline,
-	r.dboid = (SELECT oid FROM pg_database WHERE datname = 'regression')
-FROM pgactive.pgactive_test_replication_connection('dbname=regression') r,
-     pgactive.pgactive_get_local_nodeid() l;
- ?column? | ?column? | ?column? 
-----------+----------+----------
- f        | t        | t
-(1 row)
-
--- Probing replication connection for the local dsn will work too
--- even though the identifier is the same.
-SELECT
-	r.dboid = (SELECT oid FROM pg_database WHERE datname = current_database())
-FROM pgactive.pgactive_test_replication_connection('dbname='||current_database()) r;
+FROM pgactive._pgactive_get_node_info_private('dbname='||current_database()) r;
  ?column? 
 ----------
  t

--- a/test/sql/identifier.sql
+++ b/test/sql/identifier.sql
@@ -6,9 +6,10 @@ FROM pgactive.pgactive_get_local_nodeid();
 
 SELECT current_database() = 'postgres';
 
--- Test probing for remote node information. Note that local node and remote
--- node having different node identifiers (r.sysid = l.sysid false) as each
--- database gets unique pgactive node identifier.
+-- Test probing for replication connection and get node information of a given
+-- dsn. Note that local node and remote node having different node identifiers
+-- (r.sysid = l.sysid false) as each database gets unique pgactive node
+-- identifier.
 SELECT
 	r.sysid = l.sysid,
 	r.timeline = l.timeline,
@@ -18,30 +19,12 @@ SELECT
 	version_num = pgactive.pgactive_version_num(),
 	min_remote_version_num = pgactive.pgactive_min_remote_version_num(),
 	is_superuser = 't'
-FROM pgactive.pgactive_get_remote_nodeinfo('dbname=regression') r,
+FROM pgactive._pgactive_get_node_info_private('dbname=regression') r,
      pgactive.pgactive_get_local_nodeid() l;
 
--- pgactive.pgactive_get_remote_nodeinfo can also be used to probe the local dsn
--- and make sure it works.
 SELECT
     r.dboid = (SELECT oid FROM pg_database WHERE datname = current_database())
-FROM pgactive.pgactive_get_remote_nodeinfo('dbname='||current_database()) r;
-
--- Test probing for replication connection. Note that local node and remote
--- node having different node identifiers (r.sysid = l.sysid false) as each
--- database gets unique pgactive node identifier.
-SELECT
-	r.sysid = l.sysid,
-	r.timeline = l.timeline,
-	r.dboid = (SELECT oid FROM pg_database WHERE datname = 'regression')
-FROM pgactive.pgactive_test_replication_connection('dbname=regression') r,
-     pgactive.pgactive_get_local_nodeid() l;
-
--- Probing replication connection for the local dsn will work too
--- even though the identifier is the same.
-SELECT
-	r.dboid = (SELECT oid FROM pg_database WHERE datname = current_database())
-FROM pgactive.pgactive_test_replication_connection('dbname='||current_database()) r;
+FROM pgactive._pgactive_get_node_info_private('dbname='||current_database()) r;
 
 -- Verify that parsing slot names then formatting them again produces round-trip
 -- output.

--- a/test/t/020_standalone.pl
+++ b/test/t/020_standalone.pl
@@ -16,13 +16,7 @@ use utils::nodemanagement;
 my $node_a = PostgreSQL::Test::Cluster->new('node_a');
 
 $node_a->init();
-$node_a->append_conf('postgresql.conf', q{
-wal_level = logical
-track_commit_timestamp = on
-shared_preload_libraries = 'pgactive'
-pgactive.skip_ddl_replication = false
-});
-
+pgactive_update_postgresql_conf($node_a);
 $node_a->start;
 
 $node_a->safe_psql('postgres', qq{CREATE DATABASE $pgactive_test_dbname;});


### PR DESCRIPTION
This commit combines various pgactive connection testing functions pgactive_test_replication_connection(),
pgactive_test_remote_connectback() and pgactive_get_remote_nodeinfo() into one single function _pgactive_get_node_info_private(). This way not only reduces code, but also it reduces 2 pgactive functions for the end-user without losing any functionality i.e. all that these functions are doing is now moved to the new function. Also, the new function is marked as internal (prefixed with _pgactive and suffixed with _private just like any other pgactive internal function so that it represents that it's not intended for end-user avoiding inconsiderate use.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
