### PR TITLE
Emit PQerrorMessage() optionally

### DIFF
--- a/include/pgactive_internal.h
+++ b/include/pgactive_internal.h
@@ -111,5 +111,5 @@ extern int	pgactive_find_other_exec(const char *argv0, const char *target,
 
 extern uint64 GenerateNodeIdentifier(void);
 
-char	   *get_connect_string(const char *servername);
+extern char *get_connect_string(const char *servername);
 #endif							/* pgactive_INTERNAL_H */

--- a/src/pgactive_remotecalls.c
+++ b/src/pgactive_remotecalls.c
@@ -81,7 +81,7 @@ pgactive_connect_nonrepl(const char *connstring, const char *appnamesuffix, bool
 	{
 		ereport(FATAL,
 				(errmsg("could not connect to the server in non-replication mode: %s",
-						PQerrorMessage(nonrepl_conn))));
+						GetPQerrorMessage(nonrepl_conn))));
 	}
 
 	return nonrepl_conn;

--- a/test/t/047_verify_pgactive_guc_settings.pl
+++ b/test/t/047_verify_pgactive_guc_settings.pl
@@ -194,6 +194,18 @@ $result = !find_in_log($node_0,
 	$logstart_0);
 ok($result, "No error out as soon as local node can connect to one remote node to compare with");
 
+# Check that generic error for connection failure is emitted
+$node_0->append_conf('postgresql.conf', qq(pgactive.debug_trace_connection_errors = false));
+$node_0->reload;
+
+# Must not use safe_psql since we expect an error here
+($psql_ret, $psql_stdout, $psql_stderr) = ('','', '');
+($psql_ret, $psql_stdout, $psql_stderr) = $node_0->psql(
+    $pgactive_test_dbname,
+    q[SELECT * FROM pgactive.pgactive_get_remote_nodeinfo('dbname=unknown');]);
+like($psql_stderr, qr/.*FATAL.*could not connect to the server in non-replication mode: connection failed/,
+     "generic error for connection failure is detected");
+
 $node_0->stop;
 $node_1->stop;
 

--- a/test/t/utils/nodemanagement.pm
+++ b/test/t/utils/nodemanagement.pm
@@ -201,6 +201,7 @@ sub pgactive_update_postgresql_conf {
             pgactive.max_nodes = 20
             pgactive.ddl_lock_acquire_timeout = $lock_acquire_timeout
             lock_timeout = $lock_acquire_timeout
+            pgactive.debug_trace_connection_errors = true
     ));
 }
 


### PR DESCRIPTION
This commit adds a GUC to decide emitting PQerrorMessage() or a generic connection failure message. This helps hide sensitive info because the PQerrorMessage() can report full connection string at times after a connection fails, and that can contain sensitive info like host address, passwords etc. With this GUC, by default, a generic connection failure message is emitted, if wanted the superuser can change the setting.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
