### PR TITLE
Use correct function in TAP test added by commit e5037c51

### DIFF
--- a/test/t/047_verify_pgactive_guc_settings.pl
+++ b/test/t/047_verify_pgactive_guc_settings.pl
@@ -202,8 +202,8 @@ $node_0->reload;
 ($psql_ret, $psql_stdout, $psql_stderr) = ('','', '');
 ($psql_ret, $psql_stdout, $psql_stderr) = $node_0->psql(
     $pgactive_test_dbname,
-    q[SELECT * FROM pgactive.pgactive_get_remote_nodeinfo('dbname=unknown');]);
-like($psql_stderr, qr/.*FATAL.*could not connect to the server in non-replication mode: connection failed/,
+    q[SELECT * FROM pgactive._pgactive_get_node_info_private('dbname=unknown');]);
+like($psql_stderr, qr/.*ERROR.*could not connect to the server in replication mode: connection failed/,
      "generic error for connection failure is detected");
 
 $node_0->stop;


### PR DESCRIPTION
Commit e5037c51 added a TAP test that was using pgactive_get_remote_nodeinfo(), but the commit 03e7828c renamed that function to _pgactive_get_node_info_private. So use that to fix TAP test failure.

Should have been taken care by commit e5037c51.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
