### PR TITLE
Use fork and execv in place of system command

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -481,8 +481,6 @@ typedef struct pgactiveWorkerControl
 	bool		is_supervisor_restart;
 	/* Pause worker management (used in testing) */
 	bool		worker_management_paused;
-	/* Is local node restoring dump of remote node? */
-	bool		in_init_exec_dump_restore;
 	/* Latch for the supervisor worker */
 	Latch	   *supervisor_latch;
 	/* Array members, of size pgactive_max_workers */

--- a/src/pgactive.c
+++ b/src/pgactive.c
@@ -806,22 +806,6 @@ pgactive_do_not_replicate_check_hook(bool *newvalue, void **extra, GucSource sou
 	if (source != PGC_S_CLIENT)
 		return false;
 
-	/*
-	 * Allow pgactive.do_not_replicate to be set only during local node is
-	 * restoring from the dump of remote node.
-	 */
-	if (pgactiveWorkerCtl != NULL)
-	{
-		bool		in_init_exec_dump_restore;
-
-		LWLockAcquire(pgactiveWorkerCtl->lock, LW_EXCLUSIVE);
-		in_init_exec_dump_restore = pgactiveWorkerCtl->in_init_exec_dump_restore;
-		LWLockRelease(pgactiveWorkerCtl->lock);
-
-		if (!in_init_exec_dump_restore)
-			return false;
-	}
-
 	Assert(IsUnderPostmaster);
 
 	return true;

--- a/src/pgactive_shmem.c
+++ b/src/pgactive_shmem.c
@@ -174,8 +174,6 @@ pgactive_worker_shmem_startup(void)
 		/* Worker management starts unpaused */
 		pgactiveWorkerCtl->worker_management_paused = false;
 
-		pgactiveWorkerCtl->in_init_exec_dump_restore = false;
-
 		/*
 		 * The postmaster keeps track of a generation number for pgactive
 		 * workers and increments it at each restart.
@@ -334,7 +332,6 @@ pgactive_worker_shmem_release(void)
 	LWLockAcquire(pgactiveWorkerCtl->lock, LW_EXCLUSIVE);
 	pgactive_worker_slot->worker_pid = 0;
 	pgactive_worker_slot->worker_proc = NULL;
-	pgactiveWorkerCtl->in_init_exec_dump_restore = false;
 	LWLockRelease(pgactiveWorkerCtl->lock);
 
 	pgactive_worker_type = pgactive_WORKER_EMPTY_SLOT;


### PR DESCRIPTION
This commit introduces use of more safer fork() and execv() in place of system()
command for running pg_dump and pg_restore during init_replica. Also, it adjusts
failing TAP tests.

Co-authored-by: Bharath Rupireddy <bharath.rupireddyforpostgres@gmail.com>

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
