### PR TITLE
Remove node_external_dsn parameter use in pgactive functions

### DIFF
--- a/doc/catalog-bdr-connections.md
+++ b/doc/catalog-bdr-connections.md
@@ -22,7 +22,7 @@ connection string.
   `conn_origin_sysid`        `text`                                                                                 If set, ignore this entry unless the local sysid is this.
   `conn_origin_timeline`     `oid`                                                                                  If set, ignore this entry unless the local timeline is this.
   `conn_origin_dboid`        `oid`                                                                                  If set, ignore this entry unless the local dboid is this.
-  `conn_dsn`                 `text`      `bdr.bdr_nodes``.node_local_dsn`                A libpq-style connection string specifying how to make a connection to this node from other nodes.
+  `conn_dsn`                 `text`      `bdr.bdr_nodes``.node_dsn`                A libpq-style connection string specifying how to make a connection to this node from other nodes.
   `conn_apply_delay`         `integer`                                                                              If set, milliseconds to wait before applying each transaction from the remote node. Mainly for debugging. If null, the global default applies.
   `conn_replication_sets`    `text[]`    `Node management function:``replication_sets`   Replication sets this connection should participate in, if non-default.
 

--- a/doc/catalog-bdr-nodes.md
+++ b/doc/catalog-bdr-nodes.md
@@ -57,8 +57,8 @@ names.
   `node_dboid`           `oid`                                                                                    local database oid on the cluster (node_sysid, node_timeline)
   `node_status`          `char`                                                                                   Readiness of the node: \[b\]eginning setup, \[i\]nitializing, \[c\]atchup, creating \[o\]utbound slots, \[r\]eady, \[k\]illed. Doesn\'t indicate connected/disconnected.
   `node_name`            `text`                                                                                   Name of the node
-  `node_local_dsn`       `text`       `Node management function:``node_local_dsn`      A local loopback or unix socket connection string that the node can use to connect to its self; this is only used during initial setup to make the database restore faster.
-  `node_init_from_dsn`   `text`       `Node management function:``node_external_dsn`   Connection string of the node chosen as join target. Not used after we\'ve joined the node.
+  `node_dsn`       `text`       `Node management function:``node_dsn`      A local loopback or unix socket connection string that the node can use to connect to its self; this is only used during initial setup to make the database restore faster.
+  `node_init_from_dsn`   `text`       `Node management function:``node_dsn `   Connection string of the node chosen as join target. Not used after we\'ve joined the node.
   `node_read_only`       `boolean`                                                                                False unless read-only mode for a node is turned ON.
   `node_seq_id`          `smallint`                                                                                
 

--- a/doc/functions-node-mgmt.md
+++ b/doc/functions-node-mgmt.md
@@ -21,7 +21,7 @@ Return Type
 Description
 
 
-`bdr.bdr_create_group(`*`local_node_name`*`, `*`node_external_dsn`*`, `*`node_local_dsn DEFAULT NULL`*`, `*`apply_delay integer DEFAULT NULL`*`, `*`replication_sets text[] DEFAULT ARRAY['default']`*`)`
+`bdr.bdr_create_group(`*`local_node_name`*`, `*`node_dsn `*`, `*`node_dsn DEFAULT NULL`*`, `*`apply_delay integer DEFAULT NULL`*`, `*`replication_sets text[] DEFAULT ARRAY['default']`*`)`
 
 void
 
@@ -32,12 +32,12 @@ cleaned with
 [bdr.bdr_remove](functions-node-mgmt.md#FUNCTION-BDR-REMOVE).
 The \"dsn\" (data source name) parameters are [libpq connection
 strings](https://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNSTRING).
-*`node_external_dsn`* is an arbitrary node name, which
-must be unique across the BDR group. *`node_external_dsn`*
+*`node_dsn `* is an arbitrary node name, which
+must be unique across the BDR group. *`node_dsn `*
 must be a connection string other nodes can use to connect to this node.
 It must embed any required passwords unless passwordless authentication
 is required or a suitable `.pgpass` file is created in the
-postgres home directory. If specified, *`node_local_dsn`*
+postgres home directory. If specified, *`node_dsn`*
 should be a local loopback or unix socket connection string that the
 node can use to connect to its self; this is only used during initial
 setup to make the database restore faster. *`apply_delay`*
@@ -49,7 +49,7 @@ creation, and [Replication Sets](replication-sets.md) for more on how
 replication sets work.
 
 
-`bdr.bdr_join_group(`*`local_node_name`*`, `*`node_external_dsn`*`, `*`join_using_dsn`*`, `*`node_local_dsn DEFAULT NULL`*`, `*`apply_delay integer DEFAULT NULL`*`, `*`replication_sets text[] DEFAULT ARRAY['default']`*`, `*`bypass_collation_checks boolean DEFAULT false`*`)`
+`bdr.bdr_join_group(`*`local_node_name`*`, `*`node_dsn `*`, `*`join_using_dsn`*`, `*`node_dsn DEFAULT NULL`*`, `*`apply_delay integer DEFAULT NULL`*`, `*`replication_sets text[] DEFAULT ARRAY['default']`*`, `*`bypass_collation_checks boolean DEFAULT false`*`)`
 
 void
 
@@ -64,7 +64,7 @@ The parameters are the same as `bdr.bdr_create_group()`
 except for the additional required parameter
 *`join_using_dsn`*. This must be the libpq connection
 string of the node to initialize from, i.e. the other node\'s
-*`node_external_dsn`*. Any node may be chosen as the join
+*`node_dsn `*. Any node may be chosen as the join
 target, but if possible a node with a fast and reliable network link to
 the new node should be preferred. Note that
 `bdr.bdr_join_group()` can [*not*] \"re-join\"
@@ -354,7 +354,7 @@ To create a [BDR] group on \'node1\':
 ``` PROGRAMLISTING
     SELECT bdr.bdr_create_group(
        local_node_name := 'node1',
-       node_external_dsn := 'port=5598 dbname=bdrdemo');
+       node_dsn  := 'port=5598 dbname=bdrdemo');
    
 ```
 
@@ -363,7 +363,7 @@ To join \'node2\' to [BDR] group created above:
 ``` PROGRAMLISTING
     SELECT bdr.bdr_join_group(
        local_node_name := 'node2',
-       node_external_dsn := 'port=5559 dbname=bdrdemo',
+       node_dsn  := 'port=5559 dbname=bdrdemo',
        join_using_dsn := 'port=5558 dbname=bdrdemo');
    
 ```

--- a/doc/monitoring-node-join-remove.md
+++ b/doc/monitoring-node-join-remove.md
@@ -27,7 +27,7 @@ one node is initializing (`i`):
 
 ``` PROGRAMLISTING
     SELECT * FROM bdr.bdr_nodes;
-         node_sysid      | node_timeline | node_dboid | node_status | node_name |      node_local_dsn      |    node_init_from_dsn
+         node_sysid      | node_timeline | node_dboid | node_status | node_name |      node_dsn      |    node_init_from_dsn
     ---------------------+---------------+------------+-------------+-----------+--------------------------+--------------------------
      6125823754033780536 |             1 |      16385 | r           | node1     | port=5598 dbname=bdrdemo |
      6125823714403985168 |             1 |      16386 | k           | node2     | port=5599 dbname=bdrdemo | port=5598 dbname=bdrdemo

--- a/doc/quickstart-enabling.md
+++ b/doc/quickstart-enabling.md
@@ -23,7 +23,7 @@ above on port 5598:
 ``` PROGRAMLISTING
     SELECT bdr.bdr_create_group(
       local_node_name := 'node1',
-      node_external_dsn := 'port=5598 dbname=bdrdemo host=localhost'
+      node_dsn  := 'port=5598 dbname=bdrdemo host=localhost'
 );
     
 ```
@@ -54,7 +54,7 @@ will use port 5599) from the same SQL session as above on port 5599:
 ``` PROGRAMLISTING
     SELECT bdr.bdr_join_group(
       local_node_name := 'node2',
-      node_external_dsn := 'port=5599 dbname=bdrdemo host=localhost',
+      node_dsn  := 'port=5599 dbname=bdrdemo host=localhost',
       join_using_dsn := 'port=5598 dbname=bdrdemo host=localhost'
 );
     

--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -702,7 +702,7 @@ extern void pgactive_pgactive_node_free(pgactiveNodeInfo * node);
 extern void pgactive_nodes_set_local_status(pgactiveNodeStatus status, pgactiveNodeStatus oldstatus);
 extern void pgactive_nodes_set_local_attrs(pgactiveNodeStatus status, pgactiveNodeStatus oldstatus, const int *seq_id);
 extern List *pgactive_read_connection_configs(void);
-extern List *pgactive_get_node_local_dsns(bool only_local_node);
+extern List *pgactive_get_node_dsns(bool only_local_node);
 extern int	pgactive_remote_node_seq_id(void);
 
 /* return a node name or (none) if unknown for given nodeid */

--- a/src/pgactive_catalogs.c
+++ b/src/pgactive_catalogs.c
@@ -583,17 +583,17 @@ pgactive_read_connection_configs()
 }
 
 /*
- * Get the list of node_local_dsn from pgactive_nodes table of all nodes but
+ * Get the list of node_dsn from pgactive_nodes table of all nodes but
  * excluding local node or only local node.
  */
 List *
-pgactive_get_node_local_dsns(bool only_local_node)
+pgactive_get_node_dsns(bool only_local_node)
 {
 	HeapTuple	tuple;
 	StringInfoData query;
 	int			i;
 	int			ret;
-	List	   *node_local_dsns = NIL;
+	List	   *node_dsns = NIL;
 	MemoryContext caller_ctx,
 				saved_ctx;
 	char		sysid_str[33];
@@ -611,12 +611,12 @@ pgactive_get_node_local_dsns(bool only_local_node)
 	initStringInfo(&query);
 
 	if (only_local_node)
-		appendStringInfo(&query, "SELECT node_local_dsn "
+		appendStringInfo(&query, "SELECT node_dsn "
 						 "FROM pgactive.pgactive_nodes "
 						 "WHERE (node_sysid, node_timeline, node_dboid) = ($1, $2, $3) "
 						 "AND node_status <> " pgactive_NODE_STATUS_KILLED_S " ");
 	else
-		appendStringInfo(&query, "SELECT node_local_dsn "
+		appendStringInfo(&query, "SELECT node_dsn "
 						 "FROM pgactive.pgactive_nodes "
 						 "WHERE (node_sysid, node_timeline, node_dboid) <> ($1, $2, $3) "
 						 "AND node_status <> " pgactive_NODE_STATUS_KILLED_S " ");
@@ -645,9 +645,9 @@ pgactive_get_node_local_dsns(bool only_local_node)
 		tuple = SPI_tuptable->vals[i];
 
 		tmp = SPI_getvalue(tuple, SPI_tuptable->tupdesc,
-						   getattno("node_local_dsn"));
+						   getattno("node_dsn"));
 
-		node_local_dsns = lcons(tmp, node_local_dsns);
+		node_dsns = lcons(tmp, node_dsns);
 
 	}
 
@@ -658,7 +658,7 @@ pgactive_get_node_local_dsns(bool only_local_node)
 
 	MemoryContextSwitchTo(caller_ctx);
 
-	return node_local_dsns;
+	return node_dsns;
 }
 
 void

--- a/src/pgactive_init_copy.c
+++ b/src/pgactive_init_copy.c
@@ -1260,7 +1260,7 @@ initialize_node_entry(PGconn **conn, NodeInfo * ni, char *node_name, Oid dboid,
 	printfPQExpBuffer(query, "INSERT INTO pgactive.pgactive_nodes"
 					  " (node_status, node_sysid, node_timeline,"
 					  "	node_dboid, node_name, node_init_from_dsn,"
-					  "  node_local_dsn)"
+					  "  node_dsn)"
 					  " VALUES (" pgactive_NODE_STATUS_CATCHUP_S ", '" UINT64_FORMAT "', %u, %u, %s, %s, %s);",
 					  nid, ni->local_tlid, dboid,
 					  PQescapeLiteral(*conn, node_name, strlen(node_name)),

--- a/test/expected/catalog.out
+++ b/test/expected/catalog.out
@@ -16,7 +16,7 @@ ORDER BY attnum;
       3 | node_dboid         | f
       4 | node_status        | f
       5 | node_name          | f
-      6 | node_local_dsn     | f
+      6 | node_dsn           | f
       7 | node_init_from_dsn | f
       8 | node_read_only     | f
       9 | node_seq_id        | f

--- a/test/expected/catalog_1.out
+++ b/test/expected/catalog_1.out
@@ -16,7 +16,7 @@ ORDER BY attnum;
       3 | node_dboid         | f
       4 | node_status        | f
       5 | node_name          | f
-      6 | node_local_dsn     | f
+      6 | node_dsn           | f
       7 | node_init_from_dsn | f
       8 | node_read_only     | f
       9 | node_seq_id        | f

--- a/test/expected/init_pgactive.out
+++ b/test/expected/init_pgactive.out
@@ -6,8 +6,8 @@ SELECT pgactive.pgactive_is_active_in_db();
 (1 row)
 
 SELECT pgactive.pgactive_create_group(
-	local_node_name := 'node-pg',
-	node_external_dsn := 'dbname=postgres',
+	node_name := 'node-pg',
+	node_dsn := 'dbname=postgres',
 	replication_sets := ARRAY['default', 'important', 'for-node-1']
 	);
 WARNING:  secondary unique constraint(s) exist on replicated table(s)
@@ -44,10 +44,9 @@ SELECT pgactive.pgactive_is_active_in_db();
 (1 row)
 
 SELECT pgactive.pgactive_join_group(
-	local_node_name := 'node-regression',
-	node_external_dsn := 'dbname=regression',
+	node_name := 'node-regression',
+	node_dsn := 'dbname=regression',
 	join_using_dsn := 'dbname=postgres',
-	node_local_dsn := 'dbname=regression',
 	replication_sets := ARRAY['default', 'important', 'for-node-2', 'for-node-2-insert', 'for-node-2-update', 'for-node-2-delete']
 	);
  pgactive_join_group 
@@ -106,8 +105,8 @@ SELECT conn_dsn, conn_replication_sets FROM pgactive.pgactive_connections ORDER 
  dbname=regression | {default,important,for-node-2,for-node-2-insert,for-node-2-update,for-node-2-delete}
 (2 rows)
 
-SELECT node_status, node_local_dsn, node_init_from_dsn FROM pgactive.pgactive_nodes ORDER BY node_local_dsn;
- node_status |  node_local_dsn   | node_init_from_dsn 
+SELECT node_status, node_dsn, node_init_from_dsn FROM pgactive.pgactive_nodes ORDER BY node_dsn;
+ node_status |     node_dsn      | node_init_from_dsn 
 -------------+-------------------+--------------------
  r           | dbname=postgres   | 
  r           | dbname=regression | dbname=postgres
@@ -128,8 +127,8 @@ SELECT conn_dsn, conn_replication_sets FROM pgactive.pgactive_connections ORDER 
  dbname=regression | {default,important,for-node-2,for-node-2-insert,for-node-2-update,for-node-2-delete}
 (2 rows)
 
-SELECT node_status, node_local_dsn, node_init_from_dsn FROM pgactive.pgactive_nodes ORDER BY node_local_dsn;
- node_status |  node_local_dsn   | node_init_from_dsn 
+SELECT node_status, node_dsn, node_init_from_dsn FROM pgactive.pgactive_nodes ORDER BY node_dsn;
+ node_status |     node_dsn      | node_init_from_dsn 
 -------------+-------------------+--------------------
  r           | dbname=postgres   | 
  r           | dbname=regression | dbname=postgres

--- a/test/expected/schema.out
+++ b/test/expected/schema.out
@@ -30,7 +30,7 @@ order by attrelid, attnum;
  pgactive.pgactive_nodes           |      3 | node_dboid            | f            | oid                       | t
  pgactive.pgactive_nodes           |      4 | node_status           | f            | "char"                    | t
  pgactive.pgactive_nodes           |      5 | node_name             | f            | text                      | t
- pgactive.pgactive_nodes           |      6 | node_local_dsn        | f            | text                      | f
+ pgactive.pgactive_nodes           |      6 | node_dsn              | f            | text                      | f
  pgactive.pgactive_nodes           |      7 | node_init_from_dsn    | f            | text                      | f
  pgactive.pgactive_nodes           |      8 | node_read_only        | f            | boolean                   | f
  pgactive.pgactive_nodes           |      9 | node_seq_id           | f            | smallint                  | f

--- a/test/pgactive_pgbench.sh
+++ b/test/pgactive_pgbench.sh
@@ -103,13 +103,13 @@ $PGBIN/pg_ctl -D $PGBIN/data -l $RESULTS/server.log start
 echo "pgactive-cizing node $WHALE"
 $PGBIN/psql -h $WHALE_H -p $WHALE_P postgres -c "CREATE DATABASE $WHALE_DB" >> $RESULTS/check.log 2>&1
 $PGBIN/psql -h $WHALE_H -p $WHALE_P $WHALE_DB -c "CREATE EXTENSION pgactive" >> $RESULTS/check.log 2>&1
-$PGBIN/psql -h $WHALE_H -p $WHALE_P $WHALE_DB -c "SELECT pgactive.pgactive_create_group(local_node_name := '$WHALE', node_external_dsn := 'dbname=$WHALE_DB host=$WHALE_H port=$WHALE_P')" >> $RESULTS/check.log 2>&1
+$PGBIN/psql -h $WHALE_H -p $WHALE_P $WHALE_DB -c "SELECT pgactive.pgactive_create_group(node_name := '$WHALE', node_dsn := 'dbname=$WHALE_DB host=$WHALE_H port=$WHALE_P')" >> $RESULTS/check.log 2>&1
 $PGBIN/psql -h $WHALE_H -p $WHALE_P $WHALE_DB -c "SELECT pgactive.pgactive_wait_for_node_ready()" >> $RESULTS/check.log 2>&1
 
 echo "pgactive-cizing node $PANDA"
 $PGBIN/psql -h $PANDA_H -p $PANDA_P postgres -c "CREATE DATABASE $PANDA_DB" >> $RESULTS/check.log 2>&1
 $PGBIN/psql -h $PANDA_H -p $PANDA_P $PANDA_DB -c "CREATE EXTENSION pgactive" >> $RESULTS/check.log 2>&1
-$PGBIN/psql -h $PANDA_H -p $PANDA_P $PANDA_DB -c "SELECT pgactive.pgactive_join_group(local_node_name := '$PANDA', node_external_dsn := 'dbname=$PANDA_DB host=$PANDA_H port=$PANDA_P', join_using_dsn := 'dbname=$WHALE_DB host=$WHALE_H port=$WHALE_P')" >> $RESULTS/check.log 2>&1
+$PGBIN/psql -h $PANDA_H -p $PANDA_P $PANDA_DB -c "SELECT pgactive.pgactive_join_group(node_name := '$PANDA', node_dsn := 'dbname=$PANDA_DB host=$PANDA_H port=$PANDA_P', join_using_dsn := 'dbname=$WHALE_DB host=$WHALE_H port=$WHALE_P')" >> $RESULTS/check.log 2>&1
 $PGBIN/psql -h $PANDA_H -p $PANDA_P $PANDA_DB -c "SELECT pgactive.pgactive_wait_for_node_ready()" >> $RESULTS/check.log 2>&1
 
 # Initialize pgbench

--- a/test/sql/init_pgactive.sql
+++ b/test/sql/init_pgactive.sql
@@ -3,8 +3,8 @@
 SELECT pgactive.pgactive_is_active_in_db();
 
 SELECT pgactive.pgactive_create_group(
-	local_node_name := 'node-pg',
-	node_external_dsn := 'dbname=postgres',
+	node_name := 'node-pg',
+	node_dsn := 'dbname=postgres',
 	replication_sets := ARRAY['default', 'important', 'for-node-1']
 	);
 
@@ -19,10 +19,9 @@ SELECT pgactive.pgactive_is_active_in_db();
 SELECT pgactive.pgactive_is_active_in_db();
 
 SELECT pgactive.pgactive_join_group(
-	local_node_name := 'node-regression',
-	node_external_dsn := 'dbname=regression',
+	node_name := 'node-regression',
+	node_dsn := 'dbname=regression',
 	join_using_dsn := 'dbname=postgres',
-	node_local_dsn := 'dbname=regression',
 	replication_sets := ARRAY['default', 'important', 'for-node-2', 'for-node-2-insert', 'for-node-2-update', 'for-node-2-delete']
 	);
 
@@ -45,13 +44,13 @@ SELECT count(*) FROM pg_stat_replication;
 
 \c postgres
 SELECT conn_dsn, conn_replication_sets FROM pgactive.pgactive_connections ORDER BY conn_dsn;
-SELECT node_status, node_local_dsn, node_init_from_dsn FROM pgactive.pgactive_nodes ORDER BY node_local_dsn;
+SELECT node_status, node_dsn, node_init_from_dsn FROM pgactive.pgactive_nodes ORDER BY node_dsn;
 
 SELECT 1 FROM pg_replication_slots WHERE restart_lsn <= confirmed_flush_lsn;
 
 \c regression
 SELECT conn_dsn, conn_replication_sets FROM pgactive.pgactive_connections ORDER BY conn_dsn;
-SELECT node_status, node_local_dsn, node_init_from_dsn FROM pgactive.pgactive_nodes ORDER BY node_local_dsn;
+SELECT node_status, node_dsn, node_init_from_dsn FROM pgactive.pgactive_nodes ORDER BY node_dsn;
 
 SELECT 1 FROM pg_replication_slots WHERE restart_lsn <= confirmed_flush_lsn;
 

--- a/test/t/048_pgactive_with_postgres_logicalrep.pl
+++ b/test/t/048_pgactive_with_postgres_logicalrep.pl
@@ -128,8 +128,8 @@ my $node_connstr = "port=$pgport host=$pghost dbname=$pgactive_test_dbname";
 ($psql_ret, $psql_stdout, $psql_stderr) = ('','', '');
 ($psql_ret, $psql_stdout, $psql_stderr) = $node_b->psql(
     $pgactive_test_dbname,
-    qq{ SELECT pgactive.pgactive_create_group(local_node_name := '@{[ $node_b->name ]}',
-									node_external_dsn := '$node_connstr');
+    qq{ SELECT pgactive.pgactive_create_group(node_name := '@{[ $node_b->name ]}',
+									node_dsn := '$node_connstr');
 	  }
 );
 

--- a/test/t/048_pgactive_with_postgres_logicalrep_user_mapping.pl
+++ b/test/t/048_pgactive_with_postgres_logicalrep_user_mapping.pl
@@ -128,8 +128,8 @@ my $node_connstr = "port=$pgport host=$pghost dbname=$pgactive_test_dbname";
 ($psql_ret, $psql_stdout, $psql_stderr) = ('','', '');
 ($psql_ret, $psql_stdout, $psql_stderr) = $node_b->psql(
     $pgactive_test_dbname,
-    qq{ SELECT pgactive.pgactive_create_group(local_node_name := '@{[ $node_b->name ]}',
-                                    node_external_dsn := '$node_connstr');
+    qq{ SELECT pgactive.pgactive_create_group(node_name := '@{[ $node_b->name ]}',
+                                    node_dsn := '$node_connstr');
       }
 );
 

--- a/test/t/054_failover_of_pgactive_node_in_stream_repl_user_mapping.pl
+++ b/test/t/054_failover_of_pgactive_node_in_stream_repl_user_mapping.pl
@@ -51,8 +51,8 @@ $node_0->safe_psql($pgactive_test_dbname, qq{
 # Create pgactive group with user mapping
 $node_0->safe_psql($pgactive_test_dbname, qq{
 	SELECT pgactive.pgactive_create_group(
-		local_node_name := 'node_0',
-		node_external_dsn := '$node_0_fs');});
+		node_name := 'node_0',
+		node_dsn := '$node_0_fs');});
 $node_0->safe_psql($pgactive_test_dbname, qq[
     SELECT pgactive.pgactive_wait_for_node_ready($PostgreSQL::Test::Utils::timeout_default)]);
 $node_0->safe_psql($pgactive_test_dbname, 'SELECT pgactive.pgactive_is_active_in_db()' ) eq 't'
@@ -93,8 +93,8 @@ $node_0->safe_psql($pgactive_test_dbname, qq{
 # Join pgactive group with user mapping
 $node_1->safe_psql($pgactive_test_dbname, qq{
 	SELECT pgactive.pgactive_join_group(
-		local_node_name := 'node_1',
-		node_external_dsn := '$node_1_fs',
+		node_name := 'node_1',
+		node_dsn := '$node_1_fs',
         join_using_dsn := '$node_0_fs');});
 $node_1->safe_psql($pgactive_test_dbname, qq[
     SELECT pgactive.pgactive_wait_for_node_ready($PostgreSQL::Test::Utils::timeout_default)]);

--- a/test/t/055_multiple_pgactive_groups_on_single_pg_cluster.pl
+++ b/test/t/055_multiple_pgactive_groups_on_single_pg_cluster.pl
@@ -47,8 +47,8 @@ $node_g2_c2->safe_psql($bravo, q[DROP TABLE fruits;]);
 
 $node_g2_c2->safe_psql($bravo, qq{
     SELECT pgactive.pgactive_join_group(
-        local_node_name := 'node_g2_g1_c2',
-        node_external_dsn := '$node_g2_c2_connstr',
+        node_name := 'node_g2_g1_c2',
+        node_dsn := '$node_g2_c2_connstr',
         join_using_dsn := '$node_g1_c1_connstr');});
 
 my $result = find_in_log($node_g2_c2,

--- a/test/t/utils/nodemanagement.pm
+++ b/test/t/utils/nodemanagement.pm
@@ -135,8 +135,8 @@ sub create_pgactive_group {
     $node->safe_psql(
         $pgactive_test_dbname, qq{
             SELECT pgactive.pgactive_create_group(
-                    local_node_name := '@{[ $node->name ]}',
-                    node_external_dsn := '$node_connstr'
+                    node_name := '@{[ $node->name ]}',
+                    node_dsn := '$node_connstr'
                     );
             }
     );
@@ -256,8 +256,8 @@ sub generate_pgactive_logical_join_query {
 
     my $join_query = qq{
             SELECT pgactive.pgactive_join_group(
-                    local_node_name := '@{[$local_node->name]}',
-                    node_external_dsn := '$ln_connstr',
+                    node_name := '@{[$local_node->name]}',
+                    node_dsn := '$ln_connstr',
                     join_using_dsn := '$jn_connstr'};
 
     while (my ($k,$v) = each(%params)) {
@@ -830,8 +830,8 @@ sub create_pgactive_group_with_db {
 
     $node->safe_psql($db, qq{
         SELECT pgactive.pgactive_create_group(
-            local_node_name := '$node_name',
-            node_external_dsn := '$node_connstr');});
+            node_name := '$node_name',
+            node_dsn := '$node_connstr');});
     $node->safe_psql($db, qq[
         SELECT pgactive.pgactive_wait_for_node_ready($PostgreSQL::Test::Utils::timeout_default)]);
     $node->safe_psql($db, 'SELECT pgactive.pgactive_is_active_in_db()' ) eq 't'
@@ -856,8 +856,8 @@ sub join_pgactive_group_with_db {
 
     $node->safe_psql($db, qq{
         SELECT pgactive.pgactive_join_group(
-            local_node_name := '$node_name',
-            node_external_dsn := '$node_connstr',
+            node_name := '$node_name',
+            node_dsn := '$node_connstr',
             join_using_dsn := '$upstream_node_connstr');});
     $node->safe_psql($db, qq[
         SELECT pgactive.pgactive_wait_for_node_ready($PostgreSQL::Test::Utils::timeout_default)]);


### PR DESCRIPTION
This commit gets rid of extraneous node_external_dsn parameter in pgactive functoins pgactive_create_group() and
pgactive_join_group(). These functions have node_local_dsn parameter serving the same purpose, so use it. Also, rename node_local_dsn to node_dsn to be more readable and generic. This removal makes pgactive functions more readable and easy to use.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
