### PR TITLE
Allow specifying user mapping alongwith foreign server in DSNs

### DIFF
--- a/include/pgactive_internal.h
+++ b/include/pgactive_internal.h
@@ -111,5 +111,5 @@ extern int	pgactive_find_other_exec(const char *argv0, const char *target,
 
 extern uint64 GenerateNodeIdentifier(void);
 
-extern char *get_connect_string(const char *servername);
+extern char *get_connect_string(const char *usermappinginfo);
 #endif							/* pgactive_INTERNAL_H */

--- a/include/pgactive_version.h.in
+++ b/include/pgactive_version.h.in
@@ -1,4 +1,4 @@
-#define pgactive_VERSION "2.1.0-RC2"
+#define pgactive_VERSION "2.1.0-RC3"
 #define pgactive_VERSION_NUM 20100
 #define pgactive_MIN_REMOTE_VERSION_NUM 20100
 #define pgactive_VERSION_DATE ""

--- a/src/pgactive_node_identifier.c
+++ b/src/pgactive_node_identifier.c
@@ -410,7 +410,6 @@ is_pgactive_nid_getter_function_in_stmt(ObjectType objtype, Node *object)
 								 &relation,
 								 AccessExclusiveLock,
 								 true);
-	Assert(relation == NULL);
 
 	if (!OidIsValid(address.objectId))
 		return false;

--- a/test/t/048_pgactive_with_postgres_logicalrep_user_mapping.pl
+++ b/test/t/048_pgactive_with_postgres_logicalrep_user_mapping.pl
@@ -106,7 +106,8 @@ $node_b->safe_psql($pgactive_test_dbname,
 $node_b->wait_for_subscription_sync($node_a, $appname);
 
 # No problem to create a pgactive group on the publisher
-create_pgactive_group($node_a);
+my $no_dsn = 1;
+create_pgactive_group($node_a, $no_dsn);
 
 # join the subscriber
 my $join_query = generate_pgactive_logical_join_query($node_b, $node_a);

--- a/test/t/054_failover_of_pgactive_node_in_stream_repl_user_mapping.pl
+++ b/test/t/054_failover_of_pgactive_node_in_stream_repl_user_mapping.pl
@@ -52,7 +52,7 @@ $node_0->safe_psql($pgactive_test_dbname, qq{
 $node_0->safe_psql($pgactive_test_dbname, qq{
 	SELECT pgactive.pgactive_create_group(
 		node_name := 'node_0',
-		node_dsn := '$node_0_fs');});
+		node_dsn := 'user_mapping=$node_0_user pgactive_foreign_server=$node_0_fs');});
 $node_0->safe_psql($pgactive_test_dbname, qq[
     SELECT pgactive.pgactive_wait_for_node_ready($PostgreSQL::Test::Utils::timeout_default)]);
 $node_0->safe_psql($pgactive_test_dbname, 'SELECT pgactive.pgactive_is_active_in_db()' ) eq 't'
@@ -94,8 +94,8 @@ $node_0->safe_psql($pgactive_test_dbname, qq{
 $node_1->safe_psql($pgactive_test_dbname, qq{
 	SELECT pgactive.pgactive_join_group(
 		node_name := 'node_1',
-		node_dsn := '$node_1_fs',
-        join_using_dsn := '$node_0_fs');});
+		node_dsn := 'user_mapping=$node_1_user pgactive_foreign_server=$node_1_fs',
+        join_using_dsn := 'pgactive_foreign_server=$node_0_fs user_mapping=$node_0_user');});
 $node_1->safe_psql($pgactive_test_dbname, qq[
     SELECT pgactive.pgactive_wait_for_node_ready($PostgreSQL::Test::Utils::timeout_default)]);
 $node_1->safe_psql($pgactive_test_dbname, 'SELECT pgactive.pgactive_is_active_in_db()' ) eq 't'


### PR DESCRIPTION
Commit ffea0747f4 introduced support for user mapping and foreign server in place of DSNs. With that commit, the foreign server name was passed in and current user id is obtained in to get the associated user mapping. This is a problem because a single foreign server can be associated with multiple user mappings and all the pgactive bg workers return the user that they are connected to the database, but not the actual user running the create group or join group query. Also, the full connection string is derived from both user mapping and foreign server. Therefore, this commit supports specifying both user mapping and foreign server as a key-value pair which then be used to derive connection string without relying on the current user of the pgactive bg workers.

In passing, also remove an assertion which was failing when a SQL function is dropped.

Bump pgactive_VERSION to 2.1.0-RC3.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
