### PR TITLE
Use fork and execv in place of system command for init_copy

### DIFF
--- a/src/pgactive_init_replica.c
+++ b/src/pgactive_init_replica.c
@@ -365,8 +365,8 @@ pgactive_init_exec_dump_restore(pgactiveNodeInfo * node, char *snapshot)
 
 		cmdargc = 0;
 		cmdargv[cmdargc++] = pgactive_dump_path;
-		cmdargv[cmdargc++] = "-T \"pgactive.pgactive_nodes\"";
-		cmdargv[cmdargc++] = "-T \"pgactive.pgactive_connections\"";
+		cmdargv[cmdargc++] = "--exclude-table=pgactive.pgactive_nodes";
+		cmdargv[cmdargc++] = "--exclude-table=pgactive.pgactive_connections";
 		cmdargv[cmdargc++] = "--pgactive-init-node";
 		cmdargv[cmdargc++] = arg_jobs;
 		cmdargv[cmdargc++] = arg_tmp1;


### PR DESCRIPTION
This commit introduces use of more safer fork() and execv() in place of system() command for init_copy. This is similar to what commit c811e1794cd did for init_replica.

In passing, use --exclude-table for excluding pgactive tables init_replica to be consistent.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
