### PR TITLE
Remove unused make file target for packaging pgactive source code

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -19,7 +19,6 @@ EXTRA_CLEAN = src/pgactive_init_copy$(X) src/pgactive_init_copy.o include/pgacti
 	test/regression.diffs test/regression.out \
 	pgactive_init_copy_postgres.log home tmp_test_* \
 	pgactive_dump$(X) $(pgactive_DUMP_OBJS) \
-	${distdir}.tar.bz2
 
 # When in development add -Werror.
 PG_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/src/$(pgactive_PGVERCOMPAT_INCDIR) -I$(libpq_srcdir) -Wall -Wmissing-prototypes -Wmissing-declarations $(EXTRA_CFLAGS)
@@ -137,8 +136,6 @@ export GIT_DIR
 export GIT_WORK_TREE
 
 include $(PGXS)
-
-pgactive_VERSION=$(shell awk '/^.define pgactive_VERSION / { print $3; }' ${pgactive_abs_srcdir}/pgactive_version.h.in | cut -d '"' -f 2)
 
 $(info Building against PostgreSQL $(MAJORVERSION))
 
@@ -290,19 +287,6 @@ endif
 # do not have (e.g. buildfarm clients).
 installcheck:
 	@echo "Cannot run installcheck as tests need custom configuration"
-
-distdir = pgactive-$(pgactive_VERSION)
-git-dist: clean
-	rm -f .distgitrev .distgittag
-	if ! git diff-index --quiet HEAD; then echo >&2 "WARNING: git working tree has uncommitted changes to tracked files which were INCLUDED"; fi
-	if [ -n "`git ls-files --exclude-standard --others`" ]; then echo >&2 "WARNING: git working tree has unstaged files which were IGNORED!"; fi
-	echo $(GITHASH) > .distgitrev
-	git name-rev --tags --name-only `cat .distgitrev` > .distgittag
-	git ls-tree -r -t --full-tree HEAD --name-only |\
-	  tar cjf "${distdir}.tar.bz2" --no-recursion --owner=root --group=root --mode=u=rwX,go=rX --transform="s|^|${distdir}/|" -T - \
-	    .distgitrev .distgittag
-	echo >&2 "Prepared ${distdir}.tar.bz2 for rev=`cat .distgitrev`, tag=`cat .distgittag`"
-	rm -f .distgitrev .distgittag
 
 distclean maintainer-clean: clean
 # Place the maintainer-clean before removing Makefile down below because they


### PR DESCRIPTION
This commit removes unused make file target that packs/zips/tars pgactive source code.

In passing, fix the following error emitted during make distclean awk: fatal: cannot open file
`/path_to_source_code/pgactive/pgactive_version.h.in' for reading: No such file or directory

pgactive make file doesn't need pgactive_VERSION to be defined at all, so this commit removes the awk statement completely.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
