### PR TITLE
Emit better error message when pgactive is not setup yet

### DIFF
--- a/test/expected/init.out
+++ b/test/expected/init.out
@@ -18,3 +18,18 @@ CREATE EXTENSION pgactive;
 -- DDL lock state before pgactive comes up
 SELECT * FROM pgactive.pgactive_get_global_locks_info();
 ERROR:  pgactive is not active in this database
+-- pgactive functions must behave sanely when the database hasn't been added
+-- yet to the pgactive group.
+CREATE DATABASE test;
+\c test
+CREATE EXTENSION pgactive;
+SELECT pgactive.pgactive_get_local_nodeid();
+ERROR:  pgactive is not active in this database
+SELECT pgactive.get_replication_lag_info();
+ERROR:  pgactive is not active in this database
+SELECT pgactive.pgactive_skip_changes('unknown', 0, 0, '0/FFFFFFFF');
+ERROR:  pgactive is not active in this database
+SELECT pgactive.pgactive_get_global_locks_info();
+ERROR:  pgactive is not active in this database
+\c regression
+DROP DATABASE test;

--- a/test/sql/init.sql
+++ b/test/sql/init.sql
@@ -22,3 +22,18 @@ CREATE EXTENSION pgactive;
 
 -- DDL lock state before pgactive comes up
 SELECT * FROM pgactive.pgactive_get_global_locks_info();
+
+-- pgactive functions must behave sanely when the database hasn't been added
+-- yet to the pgactive group.
+CREATE DATABASE test;
+
+\c test
+CREATE EXTENSION pgactive;
+SELECT pgactive.pgactive_get_local_nodeid();
+SELECT pgactive.get_replication_lag_info();
+SELECT pgactive.pgactive_skip_changes('unknown', 0, 0, '0/FFFFFFFF');
+SELECT pgactive.pgactive_get_global_locks_info();
+
+\c regression
+
+DROP DATABASE test;


### PR DESCRIPTION
When the database isn't joined to pgactive (right after just creating pgactive extension), if some of the pgactive functions that look for pgactive node identifier are called, they all will error out with

ERROR:  function
pgactive._pgactive_node_identifier_getter_private() does not exist

This node identifier getter function is private to pgactive, hence emit a better message in these cases.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
