### PR TITLE
Remove explicit superuser check in pgactive_get_stats

### DIFF
--- a/src/pgactive_count.c
+++ b/src/pgactive_count.c
@@ -19,7 +19,6 @@
 
 #include "fmgr.h"
 #include "funcapi.h"
-#include "miscadmin.h"
 
 #include "nodes/execnodes.h"
 
@@ -297,11 +296,6 @@ pgactive_get_stats(PG_FUNCTION_ARGS)
 {
 	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
 	size_t		current_offset;
-
-	if (!superuser())
-		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("access to pgactive_get_stats() denied as non-superuser")));
 
 	/* Construct the tuplestore and tuple descriptor */
 	InitMaterializedSRF(fcinfo, 0);


### PR DESCRIPTION
This commit removes explicit superuser check in pgactive_get_stats to allow intended users (not necessarily superusers) to access the function. The info it puts out is conflict stats, not anything sensitive as such. Note that the extension SQL file REVOKEs execute permissions from public. One can GRANT execute to the users as needed. This change keeps this function similar to all other pgactive functions/tables.

==============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
