### PR TITLE
fix pgactive--2.1.0--2.1.1.sql

### DIFF
--- a/pgactive--2.1.0--2.1.1.sql
+++ b/pgactive--2.1.0--2.1.1.sql
@@ -1,3 +1,4 @@
+SET pgactive.skip_ddl_replication = true;
 -- Everything should assume the 'pgactive' prefix
 SET LOCAL search_path = pgactive;
 
@@ -454,3 +455,6 @@ REVOKE ALL ON FUNCTION pgactive_handle_rejoin() FROM public;
 REVOKE ALL ON FUNCTION pgactive_get_node_identifier() FROM PUBLIC;
 REVOKE ALL ON FUNCTION pgactive_fdw_validator(text[], oid) FROM PUBLIC;
 REVOKE ALL ON FUNCTION pgactive_conninfo_cmp(text, text) FROM PUBLIC;
+
+RESET pgactive.skip_ddl_replication;
+RESET search_path;


### PR DESCRIPTION
pgactive.skip_ddl_replication and search_path need to be set and reset at the end, like it is done in pgactive--2.1.0.sql and pgactive--2.1.1.sql.