### PR TITLE
Handle the new "flush" parameter in LogLogicalMessage

### DIFF
--- a/src/pgactive_messaging.c
+++ b/src/pgactive_messaging.c
@@ -117,7 +117,11 @@ pgactive_send_message(StringInfo s, bool transactional)
 {
 	XLogRecPtr	lsn;
 
+#if PG_VERSION_NUM >= 170000
+	lsn = LogLogicalMessage(pgactive_LOGICAL_MSG_PREFIX, s->data, s->len, transactional, false);
+#else
 	lsn = LogLogicalMessage(pgactive_LOGICAL_MSG_PREFIX, s->data, s->len, transactional);
+#endif
 	XLogFlush(lsn);
 
 	elog(DEBUG3, "sending prepared message %p",


### PR DESCRIPTION
Core PostgreSQL added a new "flush" parameter to LogLogicalMessage in 173b56f1ef.

Basically it requests to flush the lsn in case this new parameter is set to true and the existing "transactional" parameter is set to false.

We are already requesting the lsn flush in pgactive_send_message(), so using LogLogicalMessage() with flush being "false" looks fine.