### PR TITLE
Fix a few things with pgactive_fdw check added by commit 2a8474d7

### DIFF
--- a/test/expected/init_pgactive.out
+++ b/test/expected/init_pgactive.out
@@ -5,6 +5,16 @@ SELECT pgactive.pgactive_is_active_in_db();
  f
 (1 row)
 
+\set VERBOSITY terse
+-- Verify an error case with the use of non-pgactive foreign data wrapper
+CREATE FOREIGN DATA WRAPPER dummy;
+CREATE SERVER dummy_fs FOREIGN DATA WRAPPER dummy;
+CREATE USER MAPPING FOR public SERVER dummy_fs;
+SELECT pgactive.pgactive_create_group(node_name := 'dummy_node',
+	node_dsn := 'user_mapping=public pgactive_foreign_server=dummy_fs',
+	replication_sets := ARRAY['for_dummy_node']);
+ERROR:  foreign data wrapper "dummy_fs" is not based on pgactive_fdw
+\set VERBOSITY default
 SELECT pgactive.pgactive_create_group(
 	node_name := 'node-pg',
 	node_dsn := 'dbname=postgres',

--- a/test/sql/init_pgactive.sql
+++ b/test/sql/init_pgactive.sql
@@ -2,6 +2,19 @@
 
 SELECT pgactive.pgactive_is_active_in_db();
 
+\set VERBOSITY terse
+
+-- Verify an error case with the use of non-pgactive foreign data wrapper
+CREATE FOREIGN DATA WRAPPER dummy;
+CREATE SERVER dummy_fs FOREIGN DATA WRAPPER dummy;
+CREATE USER MAPPING FOR public SERVER dummy_fs;
+
+SELECT pgactive.pgactive_create_group(node_name := 'dummy_node',
+	node_dsn := 'user_mapping=public pgactive_foreign_server=dummy_fs',
+	replication_sets := ARRAY['for_dummy_node']);
+
+\set VERBOSITY default
+
 SELECT pgactive.pgactive_create_group(
 	node_name := 'node-pg',
 	node_dsn := 'dbname=postgres',


### PR DESCRIPTION
Commit 2a8474d7 added a check to verify user-entered foreign server is associated with pgactive_fdw, if not the create or join group fails with an error with such FDW specified. However, there's no test case added to verify the fix and cover the code added. Also, it caused a memory leak for the cmd varialbe as it forgot to convert initStringInfo(&cmd); for the pg_user_mappings query to resetStringInfo(&cmd);.

This commit adds a test case to hit the error added by 2a8474d7 and fixes the memory leak issue.

In passing, it rewords the error message a bit to be consistent with the PostgreSQL messaging style. Alos, it changes the code to use ERROR instead of FATAL, because this code can be hit by a direct user SQL, a FATAL emits
"server closed the connection unexpectedly" to the client connected to the backend which is a common error even for SEGVs or any other errors.

================================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.