### PR TITLE
Replace deprecated memory context reset function

### DIFF
--- a/src/pgactive_apply.c
+++ b/src/pgactive_apply.c
@@ -2791,7 +2791,7 @@ pgactive_apply_work(PGconn *streamConn)
 			CHECK_FOR_INTERRUPTS();
 		}
 
-		MemoryContextResetAndDeleteChildren(MessageContext);
+		MemoryContextReset(MessageContext);
 	}
 }
 

--- a/src/pgactive_conflict_logging.c
+++ b/src/pgactive_conflict_logging.c
@@ -99,7 +99,7 @@ void
 pgactive_conflict_logging_cleanup(void)
 {
 	if (conflict_log_context)
-		MemoryContextResetAndDeleteChildren(conflict_log_context);
+		MemoryContextReset(conflict_log_context);
 }
 
 


### PR DESCRIPTION
MemoryContextResetAndDeleteChildren() macro was deprecated in postgres a long time ago, commit eaa5808 kept it for backward compatibility. This commit replaces all remaining uses with calls to MemoryContextReset() which was done in postgres by commit 6a72c42f.

================================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.