### PR TITLE
Move replication origin setup in shmem inside txn block

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -744,8 +744,8 @@ extern struct pg_conn *pgactive_establish_connection_and_slot(const char *dsn,
 															  const char *application_name_suffix,
 															  Name out_slot_name,
 															  pgactiveNodeId * out_nodeid,
-															  RepOriginId *out_replication_identifier,
-															  char **out_snapshot);
+															  RepOriginId *out_rep_origin_id,
+															  char *out_snapshot);
 
 extern PGconn *pgactive_connect_nonrepl(const char *connstring,
 										const char *appnamesuffix,


### PR DESCRIPTION
This commit moves replorigin_session_setup() call close to replorigin_by_name() which is inside a txn block to make replication origin lookup and setup transactional just like how postgres does.

================================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.