### PR TITLE
Make worker shmem slot release code crash-safe

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -634,7 +634,9 @@ extern void pgactive_shmem_init(void);
 
 extern pgactiveWorker * pgactive_worker_shmem_alloc(pgactiveWorkerType worker_type,
 													uint32 *ctl_idx);
-extern void pgactive_worker_shmem_free(pgactiveWorker * worker, BackgroundWorkerHandle *handle);
+extern void pgactive_worker_shmem_free(pgactiveWorker * worker,
+									   BackgroundWorkerHandle *handle,
+									   bool need_lock);
 extern void pgactive_worker_shmem_acquire(pgactiveWorkerType worker_type,
 										  uint32 worker_idx,
 										  bool free_at_rel);

--- a/src/pgactive.c
+++ b/src/pgactive.c
@@ -697,8 +697,7 @@ pgactive_bgworker_init(uint32 worker_arg, pgactiveWorkerType worker_type)
 	return;
 
 unregister:
-	pgactive_worker_shmem_free(pgactive_worker_slot, NULL);
-	pgactive_worker_slot = NULL;
+	pgactive_worker_shmem_free(pgactive_worker_slot, NULL, true);
 	proc_exit(0);				/* unregister */
 }
 

--- a/src/pgactive_apply.c
+++ b/src/pgactive_apply.c
@@ -2851,8 +2851,7 @@ pgactive_apply_main(Datum main_arg)
 	{
 		elog(LOG, "unregistering apply worker due to remote node " pgactive_NODEID_FORMAT " detach",
 			 pgactive_NODEID_FORMAT_ARGS(pgactive_apply_worker->remote_node));
-		pgactive_worker_shmem_free(pgactive_worker_slot, NULL);
-		pgactive_worker_slot = NULL;
+		pgactive_worker_shmem_free(pgactive_worker_slot, NULL, true);
 		proc_exit(0);			/* unregister */
 	}
 

--- a/src/pgactive_init_replica.c
+++ b/src/pgactive_init_replica.c
@@ -1342,8 +1342,8 @@ pgactive_init_replica(pgactiveNodeInfo * local_node)
 }
 
 /*
- * Cleanup function after catchup; makes sure we free the bgworker
- * slot for the catchup worker.
+ * Cleanup function after catchup; makes sure we free the bgworker slot for the
+ * catchup worker.
  */
 static void
 pgactive_catchup_to_lsn_cleanup(int code, Datum offset)
@@ -1356,7 +1356,8 @@ pgactive_catchup_to_lsn_cleanup(int code, Datum offset)
 	 * There's no need to unregister the worker as it was registered with
 	 * BGW_NEVER_RESTART.
 	 */
-	pgactive_worker_shmem_free(&pgactiveWorkerCtl->slots[worker_shmem_idx], NULL);
+	pgactive_worker_shmem_free(&pgactiveWorkerCtl->slots[worker_shmem_idx],
+							   NULL, true);
 }
 
 /*

--- a/src/pgactive_perdb.c
+++ b/src/pgactive_perdb.c
@@ -1078,8 +1078,7 @@ check_local_node_connectability(void)
 	return;
 
 unregister:
-	pgactive_worker_shmem_free(pgactive_worker_slot, NULL);
-	pgactive_worker_slot = NULL;
+	pgactive_worker_shmem_free(pgactive_worker_slot, NULL, true);
 	proc_exit(0);				/* unregister */
 }
 


### PR DESCRIPTION
The pgactive_worker_shmem_release() is not crash-safe currently, specifically when it is called more than once within a single pgactive worker exit path. It has to be safe to execute even if no resources have been acquired just like its friend
pgactive_worker_exit().

================================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.