### PR TITLE
Fix a bunch of memory leaks in pgactive code

### DIFF
--- a/src/pgactive.c
+++ b/src/pgactive.c
@@ -518,6 +518,7 @@ pgactive_create_slot(PGconn *streamConn, Name slot_name, char *remote_ident,
 		snprintf(snapshot, NAMEDATALEN, "%s", PQgetvalue(res, 0, 2));
 
 	PQclear(res);
+	pfree(query.data);
 }
 
 /*

--- a/src/pgactive_conflict_logging.c
+++ b/src/pgactive_conflict_logging.c
@@ -631,7 +631,7 @@ pgactive_conflict_log_serverlog(pgactiveApplyConflict * conflict)
 			break;
 	}
 
-	resetStringInfo(&s_key);
+	pfree(s_key.data);
 }
 
 

--- a/src/pgactive_ddlrep.c
+++ b/src/pgactive_ddlrep.c
@@ -203,8 +203,6 @@ pgactive_capture_ddl(Node *parsetree, const char *queryString,
 	CommandTag	tag = completionTag;
 	bool		first;
 
-	initStringInfo(&si);
-
 	/*
 	 * If the call comes from DDL executed by pgactive_replicate_ddl_command,
 	 * don't queue it as it would insert duplicate commands into the queue.
@@ -233,6 +231,8 @@ pgactive_capture_ddl(Node *parsetree, const char *queryString,
 	 */
 	active_search_path = fetch_search_path(true);
 
+	initStringInfo(&si);
+
 	/*
 	 * We have to look up each namespace name by oid and reconstruct a
 	 * search_path string. It's lucky DDL is already expensive.
@@ -259,5 +259,5 @@ pgactive_capture_ddl(Node *parsetree, const char *queryString,
 
 	pgactive_queue_ddl_command(GetCommandTagName(tag), queryString, si.data);
 
-	resetStringInfo(&si);
+	pfree(si.data);
 }

--- a/src/pgactive_ddlrep_truncate.c
+++ b/src/pgactive_ddlrep_truncate.c
@@ -278,6 +278,7 @@ pgactive_finish_truncate(void)
 
 	list_free(pgactive_truncated_tables);
 	pgactive_truncated_tables = NIL;
+	pfree(buf.data);
 }
 
 /*

--- a/src/pgactive_init_replica.c
+++ b/src/pgactive_init_replica.c
@@ -470,6 +470,8 @@ pgactive_sync_nodes(PGconn *remote_conn, pgactiveNodeInfo * local_node)
 		pgactive_copytable(local_conn, remote_conn,
 						   query.data, "COPY pgactive.pgactive_nodes FROM stdin");
 
+		pfree(query.data);
+
 		/*
 		 * Copy remote connections to the local node.
 		 *
@@ -961,10 +963,7 @@ pgactive_init_replica(pgactiveNodeInfo * local_node)
 {
 	pgactiveNodeStatus status;
 	PGconn	   *nonrepl_init_conn;
-	StringInfoData dsn;
 	pgactiveConnectionConfig *local_conn_config;
-
-	initStringInfo(&dsn);
 
 	status = local_node->status;
 

--- a/src/pgactive_messaging.c
+++ b/src/pgactive_messaging.c
@@ -51,9 +51,12 @@ pgactive_process_remote_message(StringInfo s)
 	/*
 	 * Logical WAL messages are (for some reason) encapsulated in their own
 	 * header with its own length, even though the outer CopyData knows its
-	 * length. Unwrap it.
+	 * length. Unwrap it. Create StringInfo pointing into the bigger buffer.
+	 * First free the palloc-ed memory that initStringInfo gives to not leak
+	 * any memory.
 	 */
 	initStringInfo(&message);
+	pfree(message.data);
 	message.len = pq_getmsgint(s, 4);
 	message.data = (char *) pq_getmsgbytes(s, message.len);
 	msg_type = pq_getmsgint(&message, 4);

--- a/src/pgactive_node_identifier.c
+++ b/src/pgactive_node_identifier.c
@@ -104,6 +104,8 @@ get_pgactive_nid_getter_function_dependency(void)
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
 
+	pfree(cmd.data);
+
 	return is_getter_func_part_of_extension;
 }
 

--- a/src/pgactive_perdb.c
+++ b/src/pgactive_perdb.c
@@ -1120,6 +1120,8 @@ pgactive_perdb_worker_main(Datum main_arg)
 	SetConfigOption("application_name", si.data, PGC_USERSET, PGC_S_SESSION);
 	SetConfigOption("lock_timeout", "10000", PGC_USERSET, PGC_S_SESSION);
 
+	pfree(si.data);
+
 	CurrentResourceOwner = ResourceOwnerCreate(NULL, "pgactive seq top-level resource owner");
 	pgactive_saved_resowner = CurrentResourceOwner;
 

--- a/src/pgactive_remotecalls.c
+++ b/src/pgactive_remotecalls.c
@@ -80,6 +80,8 @@ pgactive_connect_nonrepl(const char *connstring, const char *appnamesuffix, bool
 						GetPQerrorMessage(nonrepl_conn))));
 	}
 
+	pfree(dsn.data);
+
 	return nonrepl_conn;
 }
 


### PR DESCRIPTION
In a lot of places memory palloc-ed for StringInfoData (1KB for each variable) isn't pfree-d causing memory leaks. This commit frees up memory allocated for all of these variables after their use.

================================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.