### PR TITLE
Remove an old stop-gap fix for decoded changes accumulation

### DIFF
--- a/src/pgactive_output.c
+++ b/src/pgactive_output.c
@@ -129,8 +129,6 @@ static void write_rel(StringInfo out, Relation rel);
 static void write_tuple(pgactiveOutputData * data, StringInfo out, Relation rel,
 						HeapTuple tuple);
 
-static void pglReorderBufferCleanSerializedTXNs(const char *slotname);
-
 /* specify output plugin callbacks */
 void
 _PG_output_plugin_init(OutputPluginCallbacks *cb)
@@ -465,20 +463,6 @@ pg_decode_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt, bool is
 							elem->defname,
 							elem->arg ? strVal(elem->arg) : "(null)")));
 		}
-	}
-
-	if (!is_init)
-	{
-		/*
-		 * There's a potential corruption bug in PostgreSQL 10.1, 9.6.6,
-		 * 9.5.10 and 9.4.15 that can cause reorder buffers to accumulate
-		 * duplicated transactions. See
-		 * https://www.postgresql.org/message-id/CAMsr+YHdX=XECbZshDZ2CZNWGTyw-taYBnzqVfx4JzM4ExP5xg@mail.gmail.com
-		 *
-		 * We can defend against this by doing our own cleanup of any
-		 * serialized txns in the reorder buffer on startup.
-		 */
-		pglReorderBufferCleanSerializedTXNs(NameStr(MyReplicationSlot->data.name));
 	}
 
 	/*
@@ -1207,45 +1191,4 @@ pg_decode_message(LogicalDecodingContext *ctx,
 		pq_sendbytes(ctx->out, message, sz);
 		OutputPluginWrite(ctx, true);
 	}
-}
-
-/*
- * Clone of ReorderBufferCleanSerializedTXNs; see
- * https://www.postgresql.org/message-id/CAMsr+YHdX=XECbZshDZ2CZNWGTyw-taYBnzqVfx4JzM4ExP5xg@mail.gmail.com
- */
-static void
-pglReorderBufferCleanSerializedTXNs(const char *slotname)
-{
-	DIR		   *spill_dir = NULL;
-	struct dirent *spill_de;
-	struct stat statbuf;
-	char		path[MAXPGPATH * 2 + 12];
-
-	snprintf(path, sizeof(path), "pg_replslot/%s", slotname);
-
-	/* we're only handling directories here, skip if it's not our's */
-	if (lstat(path, &statbuf) == 0 && !S_ISDIR(statbuf.st_mode))
-		return;
-
-	spill_dir = AllocateDir(path);
-	while ((spill_de = ReadDir(spill_dir, path)) != NULL)
-	{
-		if (strcmp(spill_de->d_name, ".") == 0 ||
-			strcmp(spill_de->d_name, "..") == 0)
-			continue;
-
-		/* only look at names that can be ours */
-		if (strncmp(spill_de->d_name, "xid", 3) == 0)
-		{
-			snprintf(path, sizeof(path), "pg_replslot/%s/%s", slotname,
-					 spill_de->d_name);
-
-			if (unlink(path) != 0)
-				ereport(PANIC,
-						(errcode_for_file_access(),
-						 errmsg("could not remove file \"%s\": %m",
-								path)));
-		}
-	}
-	FreeDir(spill_dir);
 }


### PR DESCRIPTION
pgactive has this function pglReorderBufferCleanSerializedTXNs to fix an old (i.e. pre PG11) reorder buffer changes accumulation issue [1]. This was a stop-gap fix and the solution has been committed to upstream PostgreSQL in version 11 [2] making this fix unnecessary in pgactive. Therefore, this commit removes it.

[1] https://www.postgresql.org/message-id/CAMsr+YHdX=XECbZshDZ2CZNWGTyw-taYBnzqVfx4JzM4ExP5xg@mail.gmail.com
[2] https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=8aa75e1384b1c62e302db02e6006fc6a2885afeb

===============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
