### PR TITLE
Fix pipe_read_line compilation failure on PG17

### DIFF
--- a/src/pgactive_common.c
+++ b/src/pgactive_common.c
@@ -33,11 +33,6 @@
 static int	validate_exec(const char *path);
 #endif
 
-/* pipe_read_line() is provided by core from PG13 */
-#if PG_VERSION_NUM < 130000
-static char *pipe_read_line(char *cmd, char *line, int maxsize);
-#endif
-
 /*
  * Format slot name string from node identifiers.
  */
@@ -104,19 +99,15 @@ validate_exec(const char *path)
 }
 #endif
 
-#if PG_VERSION_NUM < 130000
 /*
- * The runtime library's popen() on win32 does not work when being
- * called from a service when running on windows <= 2000, because
- * there is no stdin/stdout/stderr.
- *
- * Executing a command in a pipe and reading the first line from it
- * is all we need.
+ * Although pipe_read_line() is provided by core for external modules starting
+ * from PG13, the way input parameters are sent to it has changed since PG17.
+ * Instead of dealing with all of these at call sites which makes code
+ * unreadable, let's maintain our own version of the function.
  */
 static char *
-pipe_read_line(char *cmd, char *line, int maxsize)
+pipe_read_line_v2(char *cmd, char *line, int maxsize)
 {
-#ifndef WIN32
 	FILE	   *pgver;
 
 	/* flush output buffers in case popen does not... */
@@ -145,132 +136,7 @@ pipe_read_line(char *cmd, char *line, int maxsize)
 		return NULL;
 
 	return line;
-#else							/* WIN32 */
-
-	SECURITY_ATTRIBUTES sattr;
-	HANDLE		childstdoutrd,
-				childstdoutwr,
-				childstdoutrddup;
-	PROCESS_INFORMATION pi;
-	STARTUPINFO si;
-	char	   *retval = NULL;
-
-	sattr.nLength = sizeof(SECURITY_ATTRIBUTES);
-	sattr.bInheritHandle = TRUE;
-	sattr.lpSecurityDescriptor = NULL;
-
-	if (!CreatePipe(&childstdoutrd, &childstdoutwr, &sattr, 0))
-		return NULL;
-
-	if (!DuplicateHandle(GetCurrentProcess(),
-						 childstdoutrd,
-						 GetCurrentProcess(),
-						 &childstdoutrddup,
-						 0,
-						 FALSE,
-						 DUPLICATE_SAME_ACCESS))
-	{
-		CloseHandle(childstdoutrd);
-		CloseHandle(childstdoutwr);
-		return NULL;
-	}
-
-	CloseHandle(childstdoutrd);
-
-	ZeroMemory(&pi, sizeof(pi));
-	ZeroMemory(&si, sizeof(si));
-	si.cb = sizeof(si);
-	si.dwFlags = STARTF_USESTDHANDLES;
-	si.hStdError = childstdoutwr;
-	si.hStdOutput = childstdoutwr;
-	si.hStdInput = INVALID_HANDLE_VALUE;
-
-	if (CreateProcess(NULL,
-					  cmd,
-					  NULL,
-					  NULL,
-					  TRUE,
-					  0,
-					  NULL,
-					  NULL,
-					  &si,
-					  &pi))
-	{
-		/* Successfully started the process */
-		char	   *lineptr;
-
-		ZeroMemory(line, maxsize);
-
-		/* Try to read at least one line from the pipe */
-		/* This may require more than one wait/read attempt */
-		for (lineptr = line; lineptr < line + maxsize - 1;)
-		{
-			DWORD		bytesread = 0;
-
-			/* Let's see if we can read */
-			if (WaitForSingleObject(childstdoutrddup, 10000) != WAIT_OBJECT_0)
-				break;			/* Timeout, but perhaps we got a line already */
-
-			if (!ReadFile(childstdoutrddup, lineptr, maxsize - (lineptr - line),
-						  &bytesread, NULL))
-				break;			/* Error, but perhaps we got a line already */
-
-			lineptr += strlen(lineptr);
-
-			if (!bytesread)
-				break;			/* EOF */
-
-			if (strchr(line, '\n'))
-				break;			/* One or more lines read */
-		}
-
-		if (lineptr != line)
-		{
-			/* OK, we read some data */
-			int			len;
-
-			/* If we got more than one line, cut off after the first \n */
-			lineptr = strchr(line, '\n');
-			if (lineptr)
-				*(lineptr + 1) = '\0';
-
-			len = strlen(line);
-
-			/*
-			 * If EOL is \r\n, convert to just \n. Because stdout is a
-			 * text-mode stream, the \n output by the child process is
-			 * received as \r\n, so we convert it to \n.  The server main.c
-			 * sets setvbuf(stdout, NULL, _IONBF, 0) which has the effect of
-			 * disabling \n to \r\n expansion for stdout.
-			 */
-			if (len >= 2 && line[len - 2] == '\r' && line[len - 1] == '\n')
-			{
-				line[len - 2] = '\n';
-				line[len - 1] = '\0';
-				len--;
-			}
-
-			/*
-			 * We emulate fgets() behaviour. So if there is no newline at the
-			 * end, we add one...
-			 */
-			if (len == 0 || line[len - 1] != '\n')
-				strcat(line, "\n");
-
-			retval = line;
-		}
-
-		CloseHandle(pi.hProcess);
-		CloseHandle(pi.hThread);
-	}
-
-	CloseHandle(childstdoutwr);
-	CloseHandle(childstdoutrddup);
-
-	return retval;
-#endif							/* WIN32 */
 }
-#endif
 
 /*
  * Find another program in our binary's directory,
@@ -303,7 +169,7 @@ pgactive_find_other_exec(const char *argv0, const char *target,
 
 	snprintf(cmd, sizeof(cmd), "\"%s\" -V", retpath);
 
-	if (!pipe_read_line(cmd, line, sizeof(line)))
+	if (!pipe_read_line_v2(cmd, line, sizeof(line)))
 		return -1;
 
 	if (sscanf(line, "%*s %*s %d", &pre_dot) != 1)


### PR DESCRIPTION
Although pipe_read_line() is provided by core for external modules starting from PG13, the way input parameters are sent to it has changed since PG17 commit 5c7038d70b [1].

Instead of dealing with all of these at call sites which makes code unreadable, let's maintain our own version of the function.

Also, get rid of WIN32 related changes as we are not there yet to support pgactive on Windows.

[1] https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=5c7038d70bb9c4d28a80b0a2051f73fafab5af3f

===============================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
