### PR TITLE
Rethink the fix for deadlock in commit 97900b23

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -713,8 +713,7 @@ extern int	pgactive_remote_node_seq_id(void);
 
 /* return a node name or (none) if unknown for given nodeid */
 extern const char *pgactive_nodeid_name(const pgactiveNodeId * const node,
-										bool missing_ok,
-										bool only_cache_lookup);
+										bool missing_ok);
 
 extern void
 			stringify_my_node_identity(char *sysid_str, Size sysid_str_size,
@@ -736,7 +735,7 @@ extern void pgactive_nodecache_invalidate(void);
 extern bool pgactive_local_node_read_only(void);
 extern char pgactive_local_node_status(void);
 extern int32 pgactive_local_node_seq_id(void);
-extern const char *pgactive_local_node_name(bool only_cache_lookup);
+extern const char *pgactive_local_node_name(void);
 
 extern void pgactive_set_node_read_only_guts(char *node_name, bool read_only, bool force);
 extern void pgactive_setup_my_cached_node_names(void);

--- a/src/pgactive_ddlrep.c
+++ b/src/pgactive_ddlrep.c
@@ -59,7 +59,7 @@ pgactive_queue_ddl_command(const char *command_tag, const char *command, const c
 
 	elog(DEBUG2, "node %s enqueuing DDL command \"%s\" "
 		 "with search_path \"%s\"",
-		 pgactive_local_node_name(false), command,
+		 pgactive_local_node_name(), command,
 		 search_path == NULL ? "" : search_path);
 
 	if (search_path == NULL)

--- a/src/pgactive_locks.c
+++ b/src/pgactive_locks.c
@@ -1797,8 +1797,8 @@ pgactive_locks_node_detached(pgactiveNodeId * node)
 		pgactive_fetch_sysid_via_node_id(pgactive_my_locks_database->lock_holder, &owner);
 
 		elog(ddl_lock_log_level(DDL_LOCK_TRACE_PEERS),
-			 LOCKTRACE "global lock held by " pgactive_NODEID_FORMAT_WITHNAME " released after node detach",
-			 pgactive_NODEID_FORMAT_WITHNAME_ARGS(*node));
+			 LOCKTRACE "global lock held by " pgactive_NODEID_FORMAT " released after node detach",
+			 pgactive_NODEID_FORMAT_ARGS(*node));
 
 		peer_holds_lock = pgactive_nodeid_eq(node, &owner);
 		CommitTransactionCommand();
@@ -2591,14 +2591,4 @@ pgactive_get_global_locks_info(PG_FUNCTION_ARGS)
 
 	returnTuple = heap_form_tuple(tupleDesc, values, isnull);
 	PG_RETURN_DATUM(HeapTupleGetDatum(returnTuple));
-}
-
-/*
- * A simple wrapper to check if calling process is currently holding pgactive_locks
- * shared memory lock.
- */
-bool
-IspgactiveLocksShmemLockHeldByMe(void)
-{
-	return pgactive_locks_ctl == NULL ? false : LWLockHeldByMe(pgactive_locks_ctl->lock);
 }

--- a/src/pgactive_perdb.c
+++ b/src/pgactive_perdb.c
@@ -522,7 +522,7 @@ pgactive_maintain_db_workers(void)
 				{
 					elog(DEBUG1, "need to drop slot %s of detached node %s",
 						 NameStr(s->data.name),
-						 pgactive_nodeid_name(node, true, false));
+						 pgactive_nodeid_name(node, true));
 					drop = lappend(drop, pstrdup(NameStr(s->data.name)));
 				}
 			}
@@ -808,8 +808,8 @@ pgactive_maintain_db_workers(void)
 		/* Set the display name in 'ps' etc */
 		snprintf(bgw.bgw_name, BGW_MAXLEN,
 				 "pgactive apply worker for %s to %s",
-				 pgactive_nodeid_name(&target, true, false),
-				 pgactive_nodeid_name(&myid, true, false));
+				 pgactive_nodeid_name(&target, true),
+				 pgactive_nodeid_name(&myid, true));
 
 		/* Allocate a new shmem slot for this apply worker */
 		worker = pgactive_worker_shmem_alloc(pgactive_WORKER_APPLY, &slot);


### PR DESCRIPTION
This commit rethinks the fix provided for deadlock reported in commit 97900b23 in the context that it used LWLockHeldByMe for pgactive_locks shared memory. The fact is that LWLockHeldByMe can get costlier as it just loops over all the locks held by the backend and it is supposed to be used only for debug purposes.

To avoid the deadlock reported in commit 97900b23, alternate simple fix is to just not use pgactive_NODEID_FORMAT_WITHNAME_ARGS to report node name in pgactive_locks_node_detached, but using node id there is sufficient in the log messages.

While on this, remove another usage of LWLockHeldByMe in pgactive_get_last_applied_xact_info for the same reason that it is supposed to be used only for debug purposes.

===============================================================================
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
