### PR TITLE
Stamp pgactive CI with Postgres REL_17_STABLE

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -11,7 +11,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        version: [master, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
+        version: [
+          master,
+          REL_17_STABLE,
+          REL_16_STABLE,
+          REL_15_STABLE,
+          REL_14_STABLE,
+          REL_13_STABLE,
+          REL_12_STABLE,
+          REL_11_STABLE]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        version: [master, REL_16_STABLE, REL_15_STABLE, REL_14_STABLE, REL_13_STABLE, REL_12_STABLE, REL_11_STABLE]
+        version: [
+          master,
+          REL_17_STABLE,
+          REL_16_STABLE,
+          REL_15_STABLE,
+          REL_14_STABLE,
+          REL_13_STABLE,
+          REL_12_STABLE,
+          REL_11_STABLE]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
@@ -55,8 +63,8 @@ jobs:
           make -C contrib/hstore install
           make -C contrib/pg_trgm install
 
-      - if: ${{ matrix.version == 'master' }}
-        name: Check pgactive code indentation (master only)
+      - if: ${{ matrix.version == 'REL_17_STABLE' }}
+        name: Check pgactive code indentation (REL_17_STABLE only)
         run: |
           cd postgres
           make -C src/tools/pg_bsd_indent/ -j4 install


### PR DESCRIPTION
This commit stamps pgactive CI with Postgres 17 stable branch as Postgres moved to 18devel branch.

============================================================================================
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
