### PR TITLE
Fix supervisor issues in per-db worker registration failure

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -361,6 +361,8 @@ typedef enum
 	pgactive_WORKER_WALSENDER
 }			pgactiveWorkerType;
 
+extern PGDLLIMPORT const char *const pgactiveWorkerTypeNames[];
+
 /*
  * pgactiveWorker entries describe shared memory slots that keep track of
  * all pgactive worker types. A slot may contain data for a number of different

--- a/src/pgactive.c
+++ b/src/pgactive.c
@@ -213,6 +213,16 @@ static const struct config_enum_entry pgactive_debug_trace_ddl_locks_level_optio
 };
 
 /*
+ * Lookup table for types of pgactive workers.
+ */
+const char *const pgactiveWorkerTypeNames[] = {
+	[pgactive_WORKER_EMPTY_SLOT] = "none",
+	[pgactive_WORKER_APPLY] = "apply worker",
+	[pgactive_WORKER_PERDB] = "per-db worker",
+	[pgactive_WORKER_WALSENDER] = "walsender",
+};
+
+/*
  * pgactive_error_severity --- get string representing elevel
  */
 const char *

--- a/src/pgactive_shmem.c
+++ b/src/pgactive_shmem.c
@@ -242,9 +242,14 @@ pgactive_worker_shmem_alloc(pgactiveWorkerType worker_type, uint32 *ctl_idx)
 			return new_entry;
 		}
 	}
+
 	ereport(ERROR,
-			(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-			 errmsg("no free pgactive worker slots - pgactive.max_workers is too low")));
+			(errcode(ERRCODE_CONFIGURATION_LIMIT_EXCEEDED),
+			 errmsg("could not find free slot for pgactve \"%s\"",
+					pgactiveWorkerTypeNames[worker_type]),
+			 errhint("Consider increasing configuration parameter \"%s\"",
+					 worker_type == pgactive_WORKER_WALSENDER ? "max_wal_senders" : "max_worker_processes")));
+
 	/* unreachable */
 }
 
@@ -278,7 +283,7 @@ pgactive_worker_shmem_free(pgactiveWorker * worker,
 			if (status == BGWH_STARTED)
 			{
 				LWLockRelease(pgactiveWorkerCtl->lock);
-				elog(ERROR, "BUG: Attempt to release shm segment for pgactive worker type=%d pid=%d that's still alive",
+				elog(ERROR, "cannot release shared memory slot for a live pgactive worker type=%d pid=%d",
 					 worker->worker_type, pid);
 			}
 		}

--- a/src/pgactive_supervisor.c
+++ b/src/pgactive_supervisor.c
@@ -49,8 +49,10 @@ static bool destroy_temp_dump_dirs_callback_registered = false;
  *
  * This is called by the supervisor during startup, and by user backends when
  * the first connection is added for a database.
+ *
+ * Returns true if the worker is started, otherwise false.
  */
-static void
+static bool
 pgactive_register_perdb_worker(Oid dboid)
 {
 	BackgroundWorkerHandle *bgw_handle;
@@ -66,13 +68,11 @@ pgactive_register_perdb_worker(Oid dboid)
 	Assert(LWLockHeldByMe(pgactiveWorkerCtl->lock));
 	dbname = get_database_name(dboid);
 
-	elog(DEBUG2, "registering per-db worker for database \"%s\" with OID %u",
+	elog(LOG, "registering pgactive per-db worker for database \"%s\" with OID %u",
 		 dbname, dboid);
 
-	worker = pgactive_worker_shmem_alloc(
-										 pgactive_WORKER_PERDB,
-										 &worker_slot_number
-		);
+	worker = pgactive_worker_shmem_alloc(pgactive_WORKER_PERDB,
+										 &worker_slot_number);
 
 	perdb = &worker->data.perdb;
 	perdb->c_dboid = dboid;
@@ -107,12 +107,28 @@ pgactive_register_perdb_worker(Oid dboid)
 	bgw.bgw_main_arg = Int32GetDatum(worker_arg);
 
 	if (!RegisterDynamicBackgroundWorker(&bgw, &bgw_handle))
-		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
-				 errmsg("registering pgactive per-db dynamic background worker failed"),
+	{
+		/*
+		 * If we can't register the per-db worker now, let's free up the
+		 * worker slot in pgactive shared memory instead of emitting an error
+		 * disturbing all other existing pgactive worker processes. Upon
+		 * seeing the WARNING, users can act accordingly. The pgactive
+		 * supervisor will anyway try registering the per-db worker in its
+		 * next scan cycle.
+		 */
+		pgactive_worker_shmem_free(worker, NULL, false);
+
+		ereport(WARNING,
+				(errcode(ERRCODE_CONFIGURATION_LIMIT_EXCEEDED),
+				 errmsg("could not register pgactive per-db worker for database \"%s\" with OID %u",
+						dbname, dboid),
 				 errhint("Consider increasing configuration parameter \"max_worker_processes\".")));
 
-	elog(DEBUG2, "successfully registered pgactive per-db worker for database \"%s\"", dbname);
+		return false;
+	}
+
+	elog(LOG, "successfully registered pgactive per-db worker for database \"%s\" with OID %u",
+		 dbname, dboid);
 
 	/*
 	 * Here, supervisor must ensure the per-db worker registered above is
@@ -150,10 +166,25 @@ pgactive_register_perdb_worker(Oid dboid)
 	 */
 	status = WaitForBackgroundWorkerStartup(bgw_handle, &pid);
 	if (status != BGWH_STARTED)
-		ereport(ERROR,
+	{
+		/*
+		 * If we can't register the per-db worker now, let's free up the
+		 * worker slot in pgactive shared memory instead of emitting an error
+		 * disturbing all other existing pgactive worker processes. Upon
+		 * seeing the WARNING, users can act accordingly. The pgactive
+		 * supervisor will anyway try registering the per-db worker in its
+		 * next scan cycle.
+		 */
+		pgactive_worker_shmem_free(worker, NULL, false);
+
+		ereport(WARNING,
 				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
-				 errmsg("could not start per-db worker for %s", dbname),
+				 errmsg("could not start pgactive per-db worker for %s",
+						dbname),
 				 errhint("More details may be available in the server log.")));
+
+		return false;
+	}
 
 	/*
 	 * Wait for per-db worker to register itself in the worker's shared memory
@@ -189,12 +220,15 @@ pgactive_register_perdb_worker(Oid dboid)
 
 	Assert(!LWLockHeldByMe(pgactiveWorkerCtl->lock));
 
+	/* Re-acquire lock for the caller */
 	LWLockAcquire(pgactiveWorkerCtl->lock, LW_EXCLUSIVE);
 
 	Assert(perdb->c_dboid == perdb->p_dboid);
-	elog(DEBUG2, "successfully started pgactive per-db worker for database \"%s\", perdb->proclatch %p, perdb->p_dboid %d",
-		 dbname, perdb->proclatch, perdb->p_dboid);
+	elog(LOG, "successfully started pgactive per-db worker for database \"%s\" with OID %u",
+		 dbname, perdb->p_dboid);
 	pfree(dbname);
+
+	return true;
 }
 
 /*
@@ -290,10 +324,14 @@ pgactive_supervisor_rescan_dbs()
 		 */
 		if (find_perdb_worker_slot(sec->objoid, NULL) == -1)
 		{
-			/* No perdb worker exists for this DB, make one */
-			pgactive_register_perdb_worker(sec->objoid);
+			/*
+			 * No perdb worker exists for this DB, try to start one. If we
+			 * can't start now, try again in the next scan cycle.
+			 */
+			if (pgactive_register_perdb_worker(sec->objoid))
+				n_new_workers++;
+
 			Assert(LWLockHeldByMe(pgactiveWorkerCtl->lock));
-			n_new_workers++;
 		}
 		else
 			elog(DEBUG2, "per-db worker for database with OID %u already exists, not registering",


### PR DESCRIPTION
This commit fixes a few issues in the way supervisor reacts when it can not register per-db worker due to background worker exhaustion in postgres. Currently, the supervisor fails with an ERROR in this situation without freeing up the per-db slot from pgactive shared memory. This causes exhaustion of all the worker slots in pgactive shared memory. Moreover, emitting ERROR upon background worker exhaustion in postgres causes the supervisor to enter a restart loop which is not good.

This commit does the following in supervisor upon bakground worker exhaustion in postgres:
- Free up the per-db worker slot in pgactive shared memory
- Emit WARNING to avoid restart loop

While here, this commit also does the following:

- Rewords certain error messages with a lookup table
- Changes per-db worker registration message levels from DEBUG to LOG to be more responsive and informative.
---------------------------------------------------------------------------------------------------------------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
