### PR TITLE
Add pgactive.connectability_check_duration GUC

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -447,6 +447,7 @@ extern bool pgactive_do_not_replicate;
 extern bool pgactive_discard_mismatched_row_attributes;
 extern int	pgactive_max_ddl_lock_delay;
 extern int	pgactive_ddl_lock_timeout;
+extern int	pgactive_connectability_check_duration;
 #ifdef USE_ASSERT_CHECKING
 extern int	pgactive_ddl_lock_acquire_timeout;
 #endif

--- a/src/pgactive.c
+++ b/src/pgactive.c
@@ -1080,6 +1080,15 @@ _PG_init(void)
 							GUC_UNIT_MS,
 							NULL, NULL, NULL);
 
+	DefineCustomIntVariable("pgactive.connectability_check_duration",
+							"Internal. Sets the amount of time (in seconds) per-db worker will keep retrying to connect.",
+							NULL,
+							&pgactive_connectability_check_duration,
+							300, 2, 600,
+							PGC_SIGHUP,
+							GUC_UNIT_S,
+							NULL, NULL, NULL);
+
 #ifdef USE_ASSERT_CHECKING
 
 	/*

--- a/test/t/058_verify_restore_of_pgactive_node_backup.pl
+++ b/test/t/058_verify_restore_of_pgactive_node_backup.pl
@@ -38,9 +38,9 @@ my $logstart_2 = get_log_size($node_2);
 
 # Detached node must unregister apply worker
 my $result = find_in_log($node_2,
-	qr!LOG: ( [A-Z0-9]+:)? unregistering per-db worker on node .* due to failure in connectability check!,
+	qr!LOG: ( [A-Z0-9]+:)? unregistering per-db worker on node .* due to failure when connecting to ourself!,
 	$logstart_2);
-ok($result, "unregistering per-db worker due to failure in connectability check is detected");
+ok($result, "unregistering per-db worker due to failure when connecting to ourself is detected");
 
 # There mustn't be any pgactive workers on restored instance
 $result = $node_2->safe_psql($pgactive_test_dbname, qq[SELECT COUNT(*) FROM pgactive.pgactive_get_workers_info();]);


### PR DESCRIPTION
This new "internal" GUC sets the total amount of time the per-db worker should try to connect in case of failed attempts. On some configuration, during the engine startup, this worker can be spawned too early and not be able to connect yet. The duration between each attempt is 1 second.
