### PR TITLE
Convey per-db worker intention of unregister to supervisor

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -317,6 +317,9 @@ typedef struct pgactivePerdbWorker
 
 	/* Oid of the database the worker is attached to - populated after start */
 	Oid			p_dboid;
+
+	/* Was the worker requested to unregister? */
+	bool		unregistered;
 }			pgactivePerdbWorker;
 
 /*
@@ -690,6 +693,16 @@ extern volatile sig_atomic_t ConfigReloadPending;
 extern void SignalHandlerForConfigReload(SIGNAL_ARGS);
 #endif
 
+/*
+ * Return codes for finding pgactive per-db worker slot in shared memory
+ */
+typedef enum
+{
+	pgactive_UNREGISTERED_PER_DB_WORKER_SLOT_FOUND = -2,
+	pgactive_PER_DB_WORKER_SLOT_NOT_FOUND = -1,
+	pgactive_PER_DB_WORKER_SLOT_FOUND = 0
+} pgactivePerDBWorkerSlotState;
+
 extern int	find_perdb_worker_slot(Oid dboid,
 								   pgactiveWorker * *worker_found);
 
@@ -967,6 +980,8 @@ extern void destroy_temp_dump_dir(int code, Datum arg);
 
 extern int	find_apply_worker_slot(const pgactiveNodeId * const remote,
 								   pgactiveWorker * *worker_found);
+
+extern void pgactive_worker_unregister(void);
 
 /*
  * Emit a generic connection failure message based on GUC setting to help not

--- a/src/pgactive_apply.c
+++ b/src/pgactive_apply.c
@@ -2868,8 +2868,9 @@ pgactive_apply_main(Datum main_arg)
 	{
 		elog(LOG, "unregistering apply worker due to remote node " pgactive_NODEID_FORMAT " detach",
 			 pgactive_NODEID_FORMAT_ARGS(pgactive_apply_worker->remote_node));
-		pgactive_worker_shmem_free(pgactive_worker_slot, NULL, true);
-		proc_exit(0);			/* unregister */
+
+		pgactive_worker_unregister();
+		pg_unreachable();
 	}
 
 	/* Read our connection configuration from the database */


### PR DESCRIPTION
Currently, per-db worker when it unregisters tells postgres to not restart (via proc_exit(0)), but doesn't tell the supervisor to not re-register. Due to this, when the supervisor next wakes up and does the db scan, it registers the per-db worker again and postgres starts a new one. This approach doesn't honour the per-db worker's intention to unregister.

As a side effect of this kind of unregistering, the supervisor, due to a race condition, gets stuck in loop in
pgactive_register_perdb_worker() when a per-db worker unregisters immediately after it is started, e.g. when local connectability check fails.

To fix these issues, the per-db worker unregistering logic is changed to the following way:
- When unregistered, a flag is set in per-db worker slot in pgactive shared memory without releaseing the slot. This flag can be seen via pgactive_get_workers_info() SQL function.
- When found a previously unregistered per-db worker, the supervisor skips registering the per-db worker again.

Since the pgactive shared memory slot for unregistered per-db worker is not released, the worker slots might get consumed if there are a lot of unregistered per-db workers. This might be okay because the chances of per-db workers unregistering is infrequent.

===========================================================================================
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
