### PR TITLE
Add support for data-only logical join

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -888,6 +888,13 @@ typedef struct pgactiveNodeIdentifier
 {
 	Oid			dboid;
 	uint64		nid;
+
+	/*
+	 * Sets --data-only option for dump while logical join of a node. When
+	 * set, user must ensure node has all required schema (data definitions)
+	 * before logically joining it to pgactive group.
+	 */
+	bool		data_only_node_init;
 }			pgactiveNodeIdentifier;
 
 typedef struct pgactiveNodeIdentifierControl
@@ -911,6 +918,8 @@ extern bool is_pgactive_nid_getter_function_drop(DropStmt *stmt);
 extern bool is_pgactive_nid_getter_function_alter(AlterFunctionStmt *stmt);
 extern bool is_pgactive_nid_getter_function_alter_owner(AlterOwnerStmt *stmt);
 extern bool is_pgactive_nid_getter_function_alter_rename(RenameStmt *stmt);
+extern void pgactive_set_data_only_node_init(Oid dboid, bool val);
+extern bool pgactive_get_data_only_node_init(Oid dboid);
 
 /* Postgres commit cfdf4dc4fc96 introduced this pseudo-event in version 12. */
 #if PG_VERSION_NUM >= 120000

--- a/pgactive--2.1.3--2.1.4.sql
+++ b/pgactive--2.1.3--2.1.4.sql
@@ -299,8 +299,9 @@ REVOKE ALL ON FUNCTION pgactive_set_connection_replication_sets(text[], text) FR
 -- The public interface for node join/addition, to be run to join a currently
 -- unconnected node with a blank database to a pgactive group.
 --
+DROP FUNCTION pgactive_join_group(text, text, text, integer, text[], boolean, boolean, boolean);
 
-CREATE OR REPLACE FUNCTION pgactive.pgactive_join_group (
+CREATE FUNCTION pgactive.pgactive_join_group (
     node_name text,
     node_dsn text,
     join_using_dsn text,
@@ -308,7 +309,8 @@ CREATE OR REPLACE FUNCTION pgactive.pgactive_join_group (
     replication_sets text[] DEFAULT ARRAY['default'],
     bypass_collation_check boolean DEFAULT false,
     bypass_node_identifier_creation boolean DEFAULT false,
-    bypass_user_tables_check boolean DEFAULT false
+    bypass_user_tables_check boolean DEFAULT false,
+    data_only_node_init boolean DEFAULT false
     )
 RETURNS void LANGUAGE plpgsql VOLATILE
 SET search_path = pgactive, pg_catalog
@@ -366,7 +368,8 @@ BEGIN
         remote_dsn := join_using_dsn,
         bypass_collation_check := bypass_collation_check,
         bypass_node_identifier_creation := bypass_node_identifier_creation,
-        bypass_user_tables_check := bypass_user_tables_check);
+        bypass_user_tables_check := bypass_user_tables_check,
+        data_only_node_init := data_only_node_init);
 
     SELECT sysid, timeline, dboid INTO localid
     FROM pgactive.pgactive_get_local_nodeid();
@@ -440,10 +443,10 @@ BEGIN
 END;
 $body$;
 
-COMMENT ON FUNCTION pgactive.pgactive_join_group(text, text, text, integer, text[], boolean, boolean, boolean) IS
+COMMENT ON FUNCTION pgactive.pgactive_join_group(text, text, text, integer, text[], boolean, boolean, boolean, boolean) IS
 'Join an existing pgactive group by connecting to a member node and copying its contents';
 
-REVOKE ALL ON FUNCTION pgactive.pgactive_join_group(text, text, text, integer, text[], boolean, boolean, boolean) FROM public;
+REVOKE ALL ON FUNCTION pgactive.pgactive_join_group(text, text, text, integer, text[], boolean, boolean, boolean, boolean) FROM public;
 
 DROP FUNCTION _pgactive_get_node_info_private (text, text);
 
@@ -477,6 +480,347 @@ REVOKE ALL ON FUNCTION _pgactive_get_node_info_private(text, text) FROM public;
 
 COMMENT ON FUNCTION _pgactive_get_node_info_private(text, text) IS
 'Verify both replication and non-replication connections to the given dsn and get node info; when specified remote_dsn ask remote node to connect back to local node';
+
+DROP FUNCTION _pgactive_begin_join_private(text, text, text, text, boolean, boolean, boolean);
+CREATE FUNCTION _pgactive_begin_join_private (
+    caller text,
+    node_name text,
+    node_dsn text,
+    remote_dsn text,
+    remote_sysid OUT text,
+    remote_timeline OUT oid,
+    remote_dboid OUT oid,
+    bypass_collation_check boolean,
+    bypass_node_identifier_creation boolean,
+    bypass_user_tables_check boolean,
+    data_only_node_init boolean
+)
+RETURNS record LANGUAGE plpgsql VOLATILE
+SET search_path = pgactive, pg_catalog
+-- SET pgactive.permit_unsafe_ddl_commands = on is removed for now
+SET pgactive.skip_ddl_replication = on
+-- SET pgactive.skip_ddl_locking = on is removed for now
+AS $body$
+DECLARE
+    localid RECORD;
+    localid_from_dsn RECORD;
+    remote_nodeinfo RECORD;
+    remote_nodeinfo_r RECORD;
+	  cur_node RECORD;
+    local_max_node_value integer;
+    local_skip_ddl_replication_value boolean;
+    local_db_collation_info_r RECORD;
+    collation_errmsg text;
+    collation_hintmsg text;
+    data_dir text;
+    temp_dump_dir text;
+    same_file_system_mount_point boolean;
+    free_disk_space1 int8;
+    free_disk_space1_p text;
+    free_disk_space2 int8;
+    free_disk_space2_p text;
+    remote_dbsize_p text;
+    current_dboid oid;
+BEGIN
+    -- Only one tx can be adding connections
+    LOCK TABLE pgactive.pgactive_connections IN EXCLUSIVE MODE;
+    LOCK TABLE pgactive.pgactive_nodes IN EXCLUSIVE MODE;
+    LOCK TABLE pg_catalog.pg_shseclabel IN EXCLUSIVE MODE;
+
+    -- Generate pgactive node identifier if asked
+    IF bypass_node_identifier_creation THEN
+      RAISE WARNING USING
+        MESSAGE = 'skipping creation of pgactive node identifier for this node',
+        HINT = 'The ''bypass_node_identifier_creation'' option is only available for pgactive_init_copy tool.';
+    ELSE
+      PERFORM pgactive._pgactive_generate_node_identifier_private();
+    END IF;
+
+    SELECT sysid, timeline, dboid INTO localid
+    FROM pgactive.pgactive_get_local_nodeid();
+
+    RAISE LOG USING MESSAGE = format('node identity of node being created is (%s,%s,%s)', localid.sysid, localid.timeline, localid.dboid);
+
+    -- If there's already an entry for ourselves in pgactive.pgactive_connections then we
+    -- know this node is part of an active pgactive group and cannot be joined to
+    -- another group.
+    PERFORM 1 FROM pgactive_connections
+    WHERE conn_sysid = localid.sysid
+      AND conn_timeline = localid.timeline
+      AND conn_dboid = localid.dboid;
+
+    IF FOUND THEN
+        RAISE USING
+            MESSAGE = 'this node is already a member of a pgactive group',
+            HINT = 'Connect to the node you wish to add and run '||caller||' from it instead.',
+            ERRCODE = 'object_not_in_prerequisite_state';
+    END IF;
+
+    -- Validate that the local connection is usable and matches the node
+    -- identity of the node we're running on.
+    --
+    -- For pgactive this will NOT check the 'dsn' if 'node_dsn' gets supplied.
+    -- We don't know if 'dsn' is even valid for loopback connections and can't
+    -- assume it is. That'll get checked later by pgactive specific code.
+    --
+    -- We'll get a null node name back at this point since we haven't inserted
+    -- our nodes record (and it wouldn't have committed yet if we had).
+    --
+    SELECT * INTO localid_from_dsn
+    FROM _pgactive_get_node_info_private(node_dsn);
+
+    IF localid_from_dsn.sysid <> localid.sysid
+        OR localid_from_dsn.timeline <> localid.timeline
+        OR localid_from_dsn.dboid <> localid.dboid
+    THEN
+        RAISE USING
+            MESSAGE = 'node identity for local dsn does not match current node',
+            DETAIL = format($$The dsn '%s' connects to a node with identity (%s,%s,%s) but the local node is (%s,%s,%s)$$,
+                node_dsn, localid_from_dsn.sysid, localid_from_dsn.timeline,
+                localid_from_dsn.dboid, localid.sysid, localid.timeline, localid.dboid),
+            HINT = 'The node_dsn parameter must refer to the node you''re running this function from.',
+            ERRCODE = 'object_not_in_prerequisite_state';
+    END IF;
+
+    IF NOT localid_from_dsn.has_required_privs THEN
+        RAISE USING
+            MESSAGE = 'node_dsn does not have required rights',
+            DETAIL = format($$The dsn '%s' connects successfully but does not have required rights.$$, node_dsn),
+            ERRCODE = 'object_not_in_prerequisite_state';
+    END IF;
+
+    IF data_only_node_init THEN
+        bypass_user_tables_check := true;
+    END IF;
+
+    IF NOT bypass_user_tables_check THEN
+      PERFORM 1 FROM pg_class r
+        INNER JOIN pg_namespace n ON r.relnamespace = n.oid
+        WHERE n.nspname NOT IN ('pg_catalog', 'pgactive', 'information_schema')
+        AND relkind = 'r' AND relpersistence = 'p';
+
+      IF FOUND THEN
+          RAISE USING
+              MESSAGE = 'database joining pgactive group has existing user tables',
+              HINT = 'Ensure no user tables in the database.',
+              ERRCODE = 'object_not_in_prerequisite_state';
+      END IF;
+    END IF;
+
+    -- Now interrogate the remote node, if specified, and sanity check its
+    -- connection too. The discovered node identity is returned if found.
+    --
+    -- This will error out if there are issues with the remote node.
+    IF remote_dsn IS NOT NULL THEN
+        SELECT * INTO remote_nodeinfo
+        FROM _pgactive_get_node_info_private(remote_dsn);
+
+        remote_sysid := remote_nodeinfo.sysid;
+        remote_timeline := remote_nodeinfo.timeline;
+        remote_dboid := remote_nodeinfo.dboid;
+
+        IF NOT remote_nodeinfo.has_required_privs THEN
+            RAISE USING
+                MESSAGE = 'connection to remote node does not have required rights',
+                DETAIL = format($$The dsn '%s' connects successfully but does not have required rights.$$, remote_dsn),
+                ERRCODE = 'object_not_in_prerequisite_state';
+        END IF;
+
+        IF remote_nodeinfo.version_num < pgactive_min_remote_version_num() THEN
+            RAISE USING
+                MESSAGE = 'remote node''s pgactive version is too old',
+                DETAIL = format($$The dsn '%s' connects successfully but the remote node version %s is less than the required version %s.$$,
+                    remote_dsn, remote_nodeinfo.version_num, pgactive_min_remote_version_num()),
+                ERRCODE = 'object_not_in_prerequisite_state';
+        END IF;
+
+        IF remote_nodeinfo.min_remote_version_num > pgactive_version_num() THEN
+            RAISE USING
+                MESSAGE = 'remote node''s pgactive version is too new or this node''s version is too old',
+                DETAIL = format($$The dsn '%s' connects successfully but the remote node version %s requires this node to run at least pgactive %s, not the current %s.$$,
+                    remote_dsn, remote_nodeinfo.version_num, remote_nodeinfo.min_remote_version_num,
+                    pgactive_min_remote_version_num()),
+                ERRCODE = 'object_not_in_prerequisite_state';
+
+        END IF;
+
+        IF remote_nodeinfo.node_status IS NULL THEN
+            RAISE USING
+                MESSAGE = 'remote node does not appear to be a fully running pgactive node',
+                DETAIL = format($$The dsn '%s' connects successfully but the target node has no entry in pgactive.pgactive_nodes.$$, remote_dsn),
+                ERRCODE = 'object_not_in_prerequisite_state';
+        ELSIF remote_nodeinfo.node_status IS DISTINCT FROM pgactive.pgactive_node_status_to_char('pgactive_NODE_STATUS_READY') THEN
+            RAISE USING
+                MESSAGE = 'remote node does not appear to be a fully running pgactive node',
+                DETAIL = format($$The dsn '%s' connects successfully but the target node has pgactive.pgactive_nodes node_status=%s instead of expected 'r'.$$, remote_dsn, remote_nodeinfo.node_status),
+                ERRCODE = 'object_not_in_prerequisite_state';
+        END IF;
+
+        SELECT setting::integer INTO local_max_node_value FROM pg_settings
+          WHERE name = 'pgactive.max_nodes';
+
+        IF local_max_node_value <> remote_nodeinfo.max_nodes THEN
+            RAISE USING
+                MESSAGE = 'joining node and pgactive group have different values for pgactive.max_nodes parameter',
+                DETAIL = format('pgactive.max_nodes value for joining node is ''%s'' and remote node is ''%s''.',
+                                local_max_node_value, remote_nodeinfo.max_nodes),
+                HINT = 'The parameter must be set to the same value on all pgactive members.',
+                ERRCODE = 'object_not_in_prerequisite_state';
+        END IF;
+
+        SELECT setting FROM pg_settings
+          WHERE name = 'data_directory' INTO data_dir;
+
+        SELECT pgactive._pgactive_get_free_disk_space(data_dir) INTO free_disk_space1;
+        SELECT pg_size_pretty(free_disk_space1) INTO free_disk_space1_p;
+        SELECT pg_size_pretty(remote_nodeinfo.dbsize) INTO remote_dbsize_p;
+
+        -- We estimate that postgres needs 20% more disk space as temporary
+        -- workspace while restoring database for running queries or building
+        -- indexes. Note that it is just an estimation, the actual disk space
+        -- needed depends on various factors. Hence we emit a warning to inform
+        -- early, not an error.
+        IF free_disk_space1 < (1.2 * remote_nodeinfo.dbsize) THEN
+          RAISE WARNING USING
+            MESSAGE = 'node might fail to join pgactive group as disk space is likely to be insufficient',
+            DETAIL = format('joining node data directory file system mount point has %s free disk space and remote database is %s in size.',
+                            free_disk_space1_p, remote_dbsize_p),
+            HINT = 'Ensure enough free space on joining node file system.',
+            ERRCODE = 'object_not_in_prerequisite_state';
+        END IF;
+
+        SELECT setting FROM pg_settings
+          WHERE name = 'pgactive.temp_dump_directory' INTO temp_dump_dir;
+
+        SELECT pgactive._pgactive_get_free_disk_space(temp_dump_dir) INTO free_disk_space2;
+        SELECT pg_size_pretty(free_disk_space2) INTO free_disk_space2_p;
+
+        -- We estimate that pg_dump needs at least 50% of database size
+        -- excluding total size of indexes on the database. Note that it is
+        -- just an estimation, the actual disk space needed depends on various
+        -- factors. Hence we emit a warning to inform early, not an error.
+        IF free_disk_space2 < ((remote_nodeinfo.dbsize - remote_nodeinfo.indexessize)/2) THEN
+          RAISE WARNING USING
+            MESSAGE = 'node might fail to join pgactive group as disk space required to store temporary dump is likely to be insufficient',
+            DETAIL = format('pgactive.temp_dump_directory file system mount point has %s free disk space and remote database is %s in size.',
+                            free_disk_space2_p, remote_dbsize_p),
+            HINT = 'Ensure enough free space on pgactive.temp_dump_directory file system.',
+            ERRCODE = 'object_not_in_prerequisite_state';
+        END IF;
+
+        SELECT pgactive._pgactive_check_file_system_mount_points(data_dir, temp_dump_dir)
+          INTO same_file_system_mount_point;
+
+        IF same_file_system_mount_point THEN
+          IF free_disk_space1 <
+             ((1.2 * remote_nodeinfo.dbsize) + ((remote_nodeinfo.dbsize - remote_nodeinfo.indexessize)/2)) THEN
+            RAISE WARNING USING
+              MESSAGE = 'node might fail to join pgactive group as disk space required to store both remote database and temporary dump is likely to be insufficient',
+              HINT = 'Ensure enough free space on joining node file system.',
+              ERRCODE = 'object_not_in_prerequisite_state';
+          END IF;
+        END IF;
+
+		-- using pg_file_settings here as pgactive.skip_ddl_replication is SET to on when entering
+		-- the function.
+		SELECT COALESCE((SELECT setting::boolean
+						 FROM pg_file_settings
+						 WHERE name = 'pgactive.skip_ddl_replication' ORDER BY seqno DESC LIMIT 1),
+						 true) INTO local_skip_ddl_replication_value;
+
+		IF local_skip_ddl_replication_value <> remote_nodeinfo.skip_ddl_replication THEN
+			RAISE USING
+				MESSAGE = 'joining node and pgactive group have different values for pgactive.skip_ddl_replication parameter',
+				DETAIL = format('pgactive.skip_ddl_replication value for joining node is ''%s'' and remote node is ''%s''.',
+								local_skip_ddl_replication_value, remote_nodeinfo.skip_ddl_replication),
+				HINT = 'The parameter must be set to the same value on all pgactive members.',
+				ERRCODE = 'object_not_in_prerequisite_state';
+		END IF;
+
+        IF local_max_node_value = remote_nodeinfo.cur_nodes THEN
+            RAISE USING
+                MESSAGE = 'cannot allow more than pgactive.max_nodes number of nodes in a pgactive group',
+                HINT = 'Increase pgactive.max_nodes parameter value on joining node as well as on all other pgactive members.',
+                ERRCODE = 'object_not_in_prerequisite_state';
+        END IF;
+
+        SELECT datcollate, datctype FROM pg_database
+          WHERE datname = current_database() INTO local_db_collation_info_r;
+
+        IF local_db_collation_info_r.datcollate <> remote_nodeinfo.datcollate OR
+           local_db_collation_info_r.datctype <> remote_nodeinfo.datctype THEN
+
+          collation_errmsg := 'joining node and remote node have different database collation settings';
+          collation_hintmsg := 'Use the same database collation settings for both nodes.';
+
+          IF bypass_collation_check THEN
+            RAISE WARNING USING
+              MESSAGE = collation_errmsg,
+              HINT = collation_hintmsg,
+              ERRCODE = 'object_not_in_prerequisite_state';
+          ELSE
+            RAISE EXCEPTION USING
+              MESSAGE = collation_errmsg,
+              HINT = collation_hintmsg,
+              ERRCODE = 'object_not_in_prerequisite_state';
+          END IF;
+        END IF;
+    END IF;
+
+
+    IF data_only_node_init THEN
+        SELECT oid FROM pg_database
+          WHERE datname = current_database() INTO current_dboid;
+        -- The per-db worker will reset data_only_node_init to false after the
+        -- pgactive_init_replica.
+        PERFORM _pgactive_set_data_only_node_init(current_dboid, true);
+    END IF;
+
+    -- Create local node record so the apply worker knows to start initializing
+    -- this node with pgactive_init_replica when it's started.
+    --
+    -- pgactive_init_copy might've created a node entry in catchup mode already, in
+    -- which case we can skip this.
+    SELECT * FROM pgactive_nodes
+    WHERE node_sysid = localid.sysid
+      AND node_timeline = localid.timeline
+      AND node_dboid = localid.dboid
+    INTO cur_node;
+
+    IF NOT FOUND THEN
+        INSERT INTO pgactive_nodes (
+            node_name,
+            node_sysid, node_timeline, node_dboid,
+            node_status, node_dsn, node_init_from_dsn
+        ) VALUES (
+            node_name,
+            localid.sysid, localid.timeline, localid.dboid,
+            pgactive.pgactive_node_status_to_char('pgactive_NODE_STATUS_BEGINNING_INIT'),
+            node_dsn, remote_dsn
+        );
+    ELSIF pgactive.pgactive_node_status_from_char(cur_node.node_status) = 'pgactive_NODE_STATUS_CATCHUP' THEN
+        RAISE DEBUG 'starting node join in pgactive_NODE_STATUS_CATCHUP';
+    ELSE
+        RAISE USING
+            MESSAGE = 'a pgactive_nodes entry for this node already exists',
+            DETAIL = format('pgactive.pgactive_nodes entry for (%s,%s,%s) named ''%s'' with status %s exists.',
+                            cur_node.node_sysid, cur_node.node_timeline, cur_node.node_dboid,
+                            cur_node.node_name, pgactive.pgactive_node_status_from_char(cur_node.node_status)),
+            ERRCODE = 'object_not_in_prerequisite_state';
+    END IF;
+
+    PERFORM pgactive._pgactive_update_seclabel_private();
+END;
+$body$;
+
+REVOKE ALL ON FUNCTION _pgactive_begin_join_private(text, text, text, text, boolean, boolean, boolean, boolean) FROM public;
+
+CREATE FUNCTION _pgactive_set_data_only_node_init(dboid oid, val boolean)
+RETURNS VOID
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION _pgactive_set_data_only_node_init(oid, boolean) FROM public;
 
 -- RESET pgactive.permit_unsafe_ddl_commands; is removed for now
 RESET pgactive.skip_ddl_replication;

--- a/src/pgactive_perdb.c
+++ b/src/pgactive_perdb.c
@@ -1292,5 +1292,6 @@ pgactive_perdb_worker_main(Datum main_arg)
 	}
 
 	perdb->p_dboid = InvalidOid;
+	pgactive_set_data_only_node_init(MyDatabaseId, false);
 	proc_exit(0);
 }

--- a/test/t/020_standalone.pl
+++ b/test/t/020_standalone.pl
@@ -158,9 +158,13 @@ $node_a->safe_psql($pgactive_test_dbname, q{SET pgactive.skip_ddl_replication = 
 # Move to new version 2.1.1.
 $node_a->safe_psql($pgactive_test_dbname, q{ALTER EXTENSION pgactive UPDATE TO '2.1.1';});
 
+# Move to new version 2.1.2.
 $node_a->safe_psql($pgactive_test_dbname, q{ALTER EXTENSION pgactive UPDATE TO '2.1.2';});
 
 # Move to new version 2.1.3.
 $node_a->safe_psql($pgactive_test_dbname, q{ALTER EXTENSION pgactive UPDATE TO '2.1.3';});
+
+# Move to new version 2.1.4.
+$node_a->safe_psql($pgactive_test_dbname, q{ALTER EXTENSION pgactive UPDATE TO '2.1.4';});
 
 done_testing();

--- a/test/t/059_misc.pl
+++ b/test/t/059_misc.pl
@@ -355,4 +355,46 @@ $node_0->psql($pgactive_test_dbname,
     FROM pgactive.pgactive_nodes n
     WHERE (n.node_sysid, n.node_timeline, n.node_dboid) != pgactive.pgactive_get_local_nodeid();]);
 
+$node_0->stop;
+$node_1->stop;
+
+# Test data-only logical join of a node
+my $node_2 = PostgreSQL::Test::Cluster->new('node_2');
+initandstart_pgactive_group($node_2);
+
+$node_2->safe_psql($pgactive_test_dbname,
+    q[CREATE TABLE fruits(id integer PRIMARY KEY, name varchar);]);
+$node_2->safe_psql($pgactive_test_dbname,
+    q[INSERT INTO fruits VALUES (1, 'Mango');]);
+
+my $node_3 = PostgreSQL::Test::Cluster->new('node_3');
+initandstart_node($node_3);
+
+# Create schema on the joining node first
+$node_3->safe_psql($pgactive_test_dbname,
+    q[CREATE TABLE fruits(id integer PRIMARY KEY, name varchar);]);
+
+# Now, join the node with data-only option set
+my $join_query = generate_pgactive_logical_join_query($node_3, $node_2, data_only_node_init => 'true');
+$node_3->safe_psql($pgactive_test_dbname, $join_query);
+
+$node_3->safe_psql($pgactive_test_dbname,
+    qq[SELECT pgactive.pgactive_wait_for_node_ready($PostgreSQL::Test::Utils::timeout_default)]);
+
+check_join_status($node_3, $node_2);
+
+wait_for_apply($node_2, $node_3);
+
+# Check data is available on all pgactive nodes after logical join
+$query = qq[SELECT COUNT(*) FROM fruits;];
+my $expected = 1;
+my $node_2_res = $node_2->safe_psql($pgactive_test_dbname, $query);
+my $node_3_res = $node_3->safe_psql($pgactive_test_dbname, $query);
+
+is($node_2_res, $expected, "pgactive node node_2 has all the data");
+is($node_3_res, $expected, "pgactive node node_3 has all the data");
+
+$node_2->stop;
+$node_3->stop;
+
 done_testing();


### PR DESCRIPTION
This commit adds an option data_only_node_init to pgactive_join_group SQL function. When set to true, the logical join syncs only the data from the upstream node not the schema. User must ensure the joining node has all required schema created  before logically joining it to pgactive group.

This helps in situations where upstream node has some of the database objects (functions, procedures etc.) that can't be or not allowed to be synced to the joining node due to security or various other reasons.

Although the approach of passing down the data_only_init_node option from SQL function pgactive_join_group to per-db worker node identifier shared memory looks inelegant, it stands out when compared to other approaches like inventing a new per-db shared memory or going with GUC. In addition, this approach, unlike the GUC, allows one to perform data_only_init_node at the database level - imagine if one wants to join multiple databases in a single postgres cluster to pgactive group at once, data_only_init_node option can just be set for each database separately.

========================================================================================
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
