### PR TITLE
Fix issues with per-db worker unregister and pgactive removal

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -707,6 +707,7 @@ typedef enum
 
 extern int	find_perdb_worker_slot(Oid dboid,
 								   pgactiveWorker * *worker_found);
+extern void free_unregistered_perdb_workers(void);
 
 extern void pgactive_maintain_db_workers(void);
 

--- a/src/pgactive_shmem.c
+++ b/src/pgactive_shmem.c
@@ -272,7 +272,7 @@ pgactive_worker_shmem_free(pgactiveWorker * worker,
 
 	if (worker->worker_type == pgactive_WORKER_PERDB)
 	{
-		pgactivePerdbWorker *perdb = &pgactive_worker_slot->data.perdb;
+		pgactivePerdbWorker *perdb = &worker->data.perdb;
 
 		/*
 		 * If unregistering per-db worker, don't release the shmem slot so

--- a/src/pgactive_supervisor.c
+++ b/src/pgactive_supervisor.c
@@ -347,6 +347,12 @@ pgactive_supervisor_rescan_dbs()
 	elog(DEBUG1, "found %i pgactive-labeled DBs; registered %i new per-db workers",
 		 pgactive_dbs, n_new_workers);
 
+	/*
+	 * Free shmem slots for all unregistered-and-pgactive-disabled perdb
+	 * workers.
+	 */
+	free_unregistered_perdb_workers();
+
 	LWLockRelease(pgactiveWorkerCtl->lock);
 
 	systable_endscan(scan);


### PR DESCRIPTION
Re-join or re-create pgactive group after pgactive_remove() is broken after commit 740473806 when per-db worker unregisters. The node is left in 'b' state as the supervisor says "per-db worker for database with OID XXXX was previously unregistered, not registering".

pgactive_remove() cannot free the shared memory slot for an unregistered per-db worker due to a race condition. Although, pgactive_remove() terminates the per-db worker, it is not guaranteed that the per-db worker will unregister. The per-db worker can die even before hitting the unregister code. It all depends on when per-db worker processes the terminate signal from backend running pgactive_remove().

This commit makes it foolproof by doing the following:

- Hard kill per-db worker via signal and unregister without affecting/restarting other postgres process in pgactive_remove().

- Wakeup supervisor after per-db worker hard kill to clean up unregistered workers without pgactive labels. Do this clean up irrespective of pgactive_remove().

- Instead of waiting for per-db worker to go away towards the end of pgactive_remove(), ensure no per-db worker is linked to the database during pgactive create or join and fail early.

===========================================================================================
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
