### PR TITLE
Fix issues with pgactive replication lag timestamps reporting

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -194,10 +194,10 @@ Your active-active PostgreSQL cluster is now initialized
 
 Replication lag measures the difference in the current state of data between instances. When using asynchronous active-active replication, a larger replication lag increases the risk of a conflict occurring if the same row is updated on different nodes increases. Monitoring replication lag lets you diagnose potential issues with your active-active replication setup and helps mitigate the risk of introducing conflicting changes into your system.
 
-pgactive provides two more ways of measuring replication lag in addition to the LSN-based lag that postgres offers. pgactive tracks for each of its replication slots the last sent and applied transaction IDs as well as last sent and applied transaction's commit timestamp using which one can understand the replication lag in a better way with a query something like below:
+pgactive provides additional information about the replication lag in addition to the LSN-based lag that PostgreSQL offers. pgactive tracks for each of its replication slots the last sent and applied transaction IDs as well as last sent and applied transaction's commit timestamp using which one can understand the replication lag in a better way. Note that
+in the additional information provided, one cannot assume last_sent_xact_id is always less than or equal to last_applied_xact_id. This is because the logical decoding and apply happens in the commit order of the transactions. So it is possible that the transaction with lesser ID is sent after the transaction with higher ID, in which case, the transaction with higher ID is applied first before the transaction with lesser ID.
 
-
-pgactive makes both replication lag methods available using the pgactive.pgactive_node_slots view. You can get the replication stats on the node using the following query:
+pgactive makes both replication lag and additional information available using the pgactive.pgactive_node_slots view. You can get the replication stats on the node using the following query:
 
 ```
 postgres=# SELECT * FROM pgactive.pgactive_node_slots;
@@ -220,20 +220,10 @@ last_applied_xact_committs | 2023-08-31 12:24:10.062739+00
 last_applied_xact_at       | 2023-08-31 12:26:40.074086+00
 ```
 
-You can use the following query to calculate the replication lag using both the transaction ID and time-based method:
+You can use the following query to calculate the replication lag in amount of WAL:
 
 ```
-postgres=# SELECT node_name, slot_name,
-        pg_size_pretty(pg_wal_lsn_diff(sent_lsn, replay_lsn)) AS lag_in_wal_bytes,
-        (last_sent_xact_id::bigint - last_applied_xact_id::bigint) AS lag_in_xact_id,
-        justify_interval(last_sent_xact_committs - last_applied_xact_committs) AS lag_in_xact_committs        
-  FROM pgactive.pgactive_node_slots;
--[ RECORD 1 ]--------+-------------------------------------
-node_name            | app_node_1
-slot_name            | pgactive_5_7396225477239069071_0_5__
-lag_in_wal_bytes     | 1024 bytes
-lag_in_xact_id       | 5
-lag_in_xact_committs | 00:02:54
+SELECT *, pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)) AS wal_to_decode FROM pg_replication_slots;
 ```
 
 ## Reviewing and correcting write conflicts

--- a/src/pgactive.c
+++ b/src/pgactive.c
@@ -2329,11 +2329,29 @@ pgactive_get_replication_lag_info(PG_FUNCTION_ARGS)
 
 		values[0] = NameGetDatum(&ws->slot->data.name);
 		values[1] = ObjectIdGetDatum(ws->last_sent_xact_id);
-		values[2] = TimestampTzGetDatum(ws->last_sent_xact_committs);
-		values[3] = TimestampTzGetDatum(ws->last_sent_xact_at);
+
+		if (ws->last_sent_xact_committs != 0)
+			values[2] = TimestampTzGetDatum(ws->last_sent_xact_committs);
+		else
+			nulls[2] = true;
+
+		if (ws->last_sent_xact_at != 0)
+			values[3] = TimestampTzGetDatum(ws->last_sent_xact_at);
+		else
+			nulls[3] = true;
+
 		values[4] = ObjectIdGetDatum(last_applied_xact_id);
-		values[5] = TimestampTzGetDatum(last_applied_xact_committs);
-		values[6] = TimestampTzGetDatum(last_applied_xact_at);
+
+		if (last_applied_xact_committs != 0)
+			values[5] = TimestampTzGetDatum(last_applied_xact_committs);
+		else
+			nulls[5] = true;
+
+		if (last_applied_xact_at != 0)
+			values[6] = TimestampTzGetDatum(last_applied_xact_at);
+		else
+			nulls[6] = true;
+
 		tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc,
 							 values, nulls);
 	}

--- a/src/pgactive_apply.c
+++ b/src/pgactive_apply.c
@@ -169,12 +169,17 @@ format_action_description(
 						 remote_nspname, remote_relname);
 	}
 
-	appendStringInfo(si,
-					 " in commit before %X/%X, xid %u committed at %s (action #%u)",
-					 LSN_FORMAT_ARGS(replorigin_session_origin_lsn),
-					 replication_origin_xid,
-					 timestamptz_to_str(replorigin_session_origin_timestamp),
-					 xact_action_counter);
+	if (replorigin_session_origin_lsn != InvalidXLogRecPtr &&
+		replication_origin_xid != InvalidTransactionId &&
+		replorigin_session_origin_timestamp != 0)
+	{
+		appendStringInfo(si,
+						 " in commit before %X/%X, xid %u committed at %s (action #%u)",
+						 LSN_FORMAT_ARGS(replorigin_session_origin_lsn),
+						 replication_origin_xid,
+						 timestamptz_to_str(replorigin_session_origin_timestamp),
+						 xact_action_counter);
+	}
 
 	if (replorigin_session_origin != InvalidRepOriginId)
 	{


### PR DESCRIPTION
When the xact_committs are 0, pgactive_node_slots reports them as the epoch time because TimestampTzGetDatum(0) gives epoch time. So, fix it by reporting NULL if any of xact_committs are 0.

Also, correct the pgactive_node_slots example in the docs which shows the diff between sent and applied xact_committs and xid as lag. The diff can get negative because the order of sending logical decoding changes and applying the changes are in the transaction commit order, so it can't be assumed that sent xid is always <= applied xid. One must treat these xact_committs and xid as additional replication lag information.

Also, fix the CONTEXT message in apply side which can have TimestampTzGetDatum(0) printed as epoch when the replication origin XID, LSN and committs are set to 0 while the context message callback is in effect.

===========================================================================================
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
