### PR TITLE
Add pgactive worker error reporting facility

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -26,6 +26,7 @@ SHLIB_LINK = $(libpq)
 
 OBJS = src/pgactive.o \
 	src/pgactive_apply.o \
+	src/pgactive_elog.o \
 	src/pgactive_dbcache.o \
 	src/pgactive_ddlrep.o \
 	src/pgactive_ddlrep_truncate.o \

--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -31,6 +31,7 @@
 #include "libpq-fe.h"
 
 #include "pgactive_config.h"
+#include "pgactive_elog.h"
 #include "pgactive_internal.h"
 #include "pgactive_version.h"
 #include "pgactive_compat.h"
@@ -383,6 +384,8 @@ typedef struct pgactiveWorker
 	/* proc entry of worker if running, or NULL */
 	PGPROC	   *worker_proc;
 
+	/* last error info of worker */
+	pgactiveLastErrorInfo last_error_info;
 	union data
 	{
 		pgactiveApplyWorker apply;

--- a/include/pgactive_elog.h
+++ b/include/pgactive_elog.h
@@ -1,0 +1,88 @@
+/* -------------------------------------------------------------------------
+ *
+ * pgactive_elog.h
+ *		pgactive error reporting facility
+ *
+ * Copyright (C) 2024, PostgreSQL Global Development Group
+ *
+ * IDENTIFICATION
+ *		pgactive_elog.h
+ *
+ * -------------------------------------------------------------------------
+ */
+#ifndef pgactive_ELOG_H
+#define pgactive_ELOG_H
+
+#include "datatype/timestamp.h"
+
+/*
+ * Define pgactive error codes for which last error info needs to be tracked.
+ * When adding new error code, remember to add corresponding entry in
+ * pgactiveErrorMessages.
+ *
+ * NB: If ever changing start and end limits for one worker, adjust other
+ * workers' start and end limits.
+ */
+
+#define PGACTIVE_TRACKED_ERRORS_CHUNK 64
+typedef enum pgactiveTrackedErrorCodes
+{
+	PGACTIVE_ERRCODE_NONE = 0,
+
+	/* perdb worker error codes start --> */
+	PGACTIVE_PERDB_WORKER_ERROR_CODE_START = 1,
+	PGACTIVE_ERROR_CODE_MAX_NODES_PARAM_MISMATCH = 2,
+
+	/* add new perdb worker error codes here */
+
+	PGACTIVE_PERDB_WORKER_ERROR_CODE_END = PGACTIVE_TRACKED_ERRORS_CHUNK,
+	/* <-- perdb worker error codes end */
+
+	/* apply worker error codes start --> */
+	PGACTIVE_APPLY_WORKER_ERROR_CODE_START = PGACTIVE_TRACKED_ERRORS_CHUNK + 1,
+	PGACTIVE_ERROR_CODE_APPLY_FAILURE,
+
+	/* add new apply worker error codes here */
+
+	PGACTIVE_APPLY_WORKER_ERROR_CODE_END = 2 * PGACTIVE_TRACKED_ERRORS_CHUNK,
+	/* <-- apply worker error codes end */
+}			pgactiveTrackedErrorCodes;
+
+extern PGDLLIMPORT const char *const pgactiveErrorMessages[];
+
+typedef struct pgactiveLastErrorInfo
+{
+	pgactiveTrackedErrorCodes errcode;
+	TimestampTz errtime;
+}			pgactiveLastErrorInfo;
+
+#define GET_FIRST_ARG(arg1, ...) arg1
+#define GET_REST_ARGS(arg1, ...) __VA_ARGS__
+
+/*
+ * Log the pgactive error message. Either call with pgactiveTrackedErrorCodes:
+ *
+ * ereport_pgactive(ERROR,
+ *                  PGACTIVE_ERRCODE_XXX,
+ *                  errmsg("...."));
+ *
+ * or just call:
+ *
+ * ereport_pgactive(ERROR,
+ *                  errmsg("...."));
+ */
+#define ereport_pgactive(elevel, ...) \
+do { \
+	pgactive_set_worker_last_error_info(pgactive_worker_slot, \
+										GET_FIRST_ARG(__VA_ARGS__, 0)); \
+	ereport(elevel, GET_REST_ARGS(__VA_ARGS__)); \
+} while(0)
+
+/* Forward declaration */
+struct pgactiveWorker;
+
+extern void pgactive_set_worker_last_error_info(struct pgactiveWorker *w,
+												pgactiveTrackedErrorCodes errcode);
+extern void pgactive_reset_worker_last_error_info(struct pgactiveWorker *w);
+
+#endif							/* pgactive_ELOG_H */

--- a/pgactive--2.1.3--2.1.4.sql
+++ b/pgactive--2.1.3--2.1.4.sql
@@ -212,7 +212,9 @@ CREATE FUNCTION pgactive_get_workers_info (
     OUT dboid oid,
     OUT worker_type text,
     OUT pid int4,
-    OUT unregistered boolean
+    OUT unregistered boolean,
+    OUT last_error text,
+    OUT last_error_time timestamptz
 )
 RETURNS SETOF record
 AS 'MODULE_PATHNAME'

--- a/src/pgactive_elog.c
+++ b/src/pgactive_elog.c
@@ -1,0 +1,69 @@
+/* -------------------------------------------------------------------------
+ *
+ * pgactive_elog.c
+ *		pgactive error reporting facility
+ *
+ * Copyright (C) 2024, PostgreSQL Global Development Group
+ *
+ * IDENTIFICATION
+ *		pgactive_elog.c
+ *
+ * -------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "pgactive.h"
+#include "pgactive_elog.h"
+
+/*
+ * Lookup table for pgactive error messages.
+ */
+const char *const pgactiveErrorMessages[] = {
+	[PGACTIVE_ERRCODE_NONE] = "none",
+	[PGACTIVE_ERROR_CODE_MAX_NODES_PARAM_MISMATCH] = "pgactive_max_nodes_parameter_mismatch",
+	[PGACTIVE_ERROR_CODE_APPLY_FAILURE] = "pgactive_apply_failure",
+};
+
+void
+pgactive_set_worker_last_error_info(struct pgactiveWorker *w,
+									pgactiveTrackedErrorCodes errcode)
+{
+	if (w == NULL)
+		return;
+
+	Assert(w->worker_type == pgactive_WORKER_PERDB ||
+		   w->worker_type == pgactive_WORKER_APPLY);
+
+	w->last_error_info.errcode = errcode;
+	w->last_error_info.errtime = GetCurrentTimestamp();
+}
+
+void
+pgactive_reset_worker_last_error_info(struct pgactiveWorker *w)
+{
+	int			errcode;
+
+	if (w == NULL)
+		return;
+
+	Assert(w->worker_type == pgactive_WORKER_PERDB ||
+		   w->worker_type == pgactive_WORKER_APPLY);
+
+	errcode = w->last_error_info.errcode;
+
+	if (w->worker_type == pgactive_WORKER_PERDB)
+	{
+		if (!(errcode >= PGACTIVE_PERDB_WORKER_ERROR_CODE_START &&
+			  errcode <= PGACTIVE_PERDB_WORKER_ERROR_CODE_END))
+			return;
+	}
+	else if (w->worker_type == pgactive_WORKER_APPLY)
+	{
+		if (!(errcode >= PGACTIVE_APPLY_WORKER_ERROR_CODE_START &&
+			  errcode <= PGACTIVE_APPLY_WORKER_ERROR_CODE_END))
+			return;
+	}
+
+	w->last_error_info.errcode = PGACTIVE_ERRCODE_NONE;
+	w->last_error_info.errtime = 0;
+}


### PR DESCRIPTION
This commit enables pgactive per-db and apply workers to report their last error into shared memory. Users can see the last error info via pgactive_get_workers_info SQL function.

One error for each per-db and apply worker is added for now. This can be extended to other errors by adding a specific pgactive error code and emitting error via the ereport_pgactive() in place of ereport()/elog().

This last error info improves observability of the pgactive setups.

===========================================================================================
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
