### PR TITLE
Ensure we have a valid snapshot when updating various system catalogs

### DIFF
--- a/src/pgactive_executor.c
+++ b/src/pgactive_executor.c
@@ -367,6 +367,8 @@ pgactive_set_node_read_only_guts(char *node_name, bool read_only, bool force)
 
 	Assert(IsTransactionState());
 
+	PushActiveSnapshot(GetTransactionSnapshot());
+
 	/*
 	 * We don't allow the user to clear read-only status while the local node
 	 * is initing.
@@ -422,6 +424,8 @@ pgactive_set_node_read_only_guts(char *node_name, bool read_only, bool force)
 		elog(ERROR, "node %s not found.", node_name);
 
 	systable_endscan(scan);
+
+	PopActiveSnapshot();
 
 	CommandCounterIncrement();
 

--- a/src/pgactive_locks.c
+++ b/src/pgactive_locks.c
@@ -1513,7 +1513,9 @@ pgactive_process_acquire_ddl_lock(const pgactiveNodeId * const node, pgactiveLoc
 			/* simple_heap_insert(rel, tup); */
 			pgactive_locks_set_commit_pending_state(pgactive_LOCKSTATE_PEER_BEGIN_CATCHUP);
 			/* CatalogTupleUpdate(rel, &tup->t_self, tup); */
+			PushActiveSnapshot(GetTransactionSnapshot());
 			CatalogTupleInsert(rel, tup);
+			PopActiveSnapshot();
 			ForceSyncCommit();	/* async commit would be too complicated */
 			table_close(rel, NoLock);
 			CommitTransactionCommand();

--- a/src/pgactive_supervisor.c
+++ b/src/pgactive_supervisor.c
@@ -40,6 +40,7 @@
 #include "utils/elog.h"
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
+#include "utils/snapmgr.h"
 
 static bool destroy_temp_dump_dirs_callback_registered = false;
 
@@ -380,6 +381,8 @@ pgactive_supervisor_createdb()
 
 	StartTransactionCommand();
 
+	PushActiveSnapshot(GetTransactionSnapshot());
+
 	/* If the DB already exists, no need to create it */
 	dboid = get_database_oid(pgactive_SUPERVISOR_DBNAME, true);
 
@@ -415,6 +418,8 @@ pgactive_supervisor_createdb()
 	{
 		elog(DEBUG3, "database " pgactive_SUPERVISOR_DBNAME " (oid=%i) already exists, not creating", dboid);
 	}
+
+	PopActiveSnapshot();
 
 	CommitTransactionCommand();
 


### PR DESCRIPTION
This was missing in some places and triggered a failed assertion due to fe8ea7a2a893.
