### PR TITLE
fix: DDL locking session hanging (#90)

### DIFF
--- a/include/pgactive.h
+++ b/include/pgactive.h
@@ -12,6 +12,7 @@
 
 #include "miscadmin.h"
 #include "access/xlogdefs.h"
+#include "executor/execdesc.h"
 #include "postmaster/bgworker.h"
 
 /* Postgres commit 7dbfea3c455e introduced SIGHUP handler in version 13. */
@@ -677,7 +678,7 @@ extern void pgactive_capture_ddl(Node *parsetree, const char *queryString,
 								 DestReceiver *dest, CommandTag completionTag);
 
 extern void pgactive_locks_shmem_init(void);
-extern void pgactive_locks_check_dml(void);
+extern void pgactive_locks_check_dml(QueryDesc *queryDesc);
 
 /* background workers and supporting functions for them */
 PGDLLEXPORT extern void pgactive_apply_main(Datum main_arg);

--- a/src/pgactive_executor.c
+++ b/src/pgactive_executor.c
@@ -520,7 +520,7 @@ pgactiveExecutorStart(QueryDesc *queryDesc, int eflags)
 	read_only_node = pgactive_local_node_read_only() && !pgactive_skip_ddl_replication;
 
 	/* check for concurrent global DDL locks */
-	pgactive_locks_check_dml();
+	pgactive_locks_check_dml(queryDesc);
 
 	/*
 	 * Are we in pgactive.replicate_ddl_command? If so, it's not safe to do


### PR DESCRIPTION
Unlock the relation if locked by toplevel transaction and a queued DDL command waiting to be replayed.

Issue #90,

As described in the issue if we try to insert in the same table which is going to be drooped by the `Node 1`. The `insert` command will apply a lock on the table, as the result when `Node 2` will try to replay (dropping the same rel) it will not and will go under a race condition.

I tried unlocking the relation and then locking it again after the DDL is replayed. It worked. But I am not sure weather unlocking a relation which was locked by the toptransaction is safe or not. So let me know if the approach looks OK to you. Thanks


Present behavior.

Node 1: 
```
app=# begin;
BEGIN
app=*# drop table foo;
DROP TABLE
```
Node 2:
```
app=# insert into foo values (1);
```
Hanging.

Node 1:
```
app=*# commit;
COMMIT
```

Node 2
```
app=# insert into foo values (1);
ERROR:  relation 34120 deleted while still in use
```
 