### PR TITLE
Use index collation when locating replicated rows

### DIFF
--- a/src/pgactive_executor.c
+++ b/src/pgactive_executor.c
@@ -235,6 +235,8 @@ build_index_scan_key(ScanKey skey, Relation rel, Relation idxrel, pgactiveTupleD
 					regop,
 					tup->values[mainattno - 1]);
 
+		skey[attoff].sk_collation = idxrel->rd_indcollation[attoff];
+
 		if (tup->isnull[mainattno - 1])
 		{
 			hasnulls = true;


### PR DESCRIPTION
Set the scan key collation from the index so replicated row lookups use the index's ordering rules.

This follows PostgreSQL commit
https://github.com/postgres/postgres/commit/5e1963fb764e9cc092e0f7b58b28985c311431d9
