### PR TITLE
Use GNU C11 for Meson builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
   license: 'Apache-2.0',
   meson_version: '>= 0.57.0',
   default_options: [
-    'c_std=gnu99',
+    'c_std=gnu11',
     'warning_level=2',
   ],
 )


### PR DESCRIPTION
PostgreSQL 19 headers require C11, but Meson builds currently force GNU C99. Use GNU C11 instead, which remains compatible with all supported PostgreSQL versions.

Issue #326 

